### PR TITLE
fix to issue 19: route not matching when query string contains %0A

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -1261,7 +1261,7 @@ class F3 extends Base {
 					'(?P<\1>[\w\-\.!~\*\'"(),\s]+)',
 					// Wildcard character in URI
 					str_replace('\*','(.*)',preg_quote($uri,'/'))
-				).'\/?(?:\?.*)?$/iu',$req,$args))
+				).'\/?(?:\?.*)?$/ium',$req,$args))
 				continue;
 			$wild=is_int(strpos($uri,'/*'));
 			// Inspect each defined route


### PR DESCRIPTION
...in it, rawurldecode makes it multiline. This would fix https://github.com/bcosca/fatfree/issues/19 - as would removing the call to rawurldecode (but that is presumably there for a reason).
