### PR TITLE
bug fix for google maps

### DIFF
--- a/lib/google.php
+++ b/lib/google.php
@@ -64,6 +64,12 @@ class Google extends Base {
 			$format='png',
 			$language='en',
 			array $markers=NULL) {
+        switch($format){
+            case 'gif': header("Content-Type: image/gif"); break;
+            case 'jpeg': header("Content-Type: image/jpeg"); break;
+            default:
+            case 'png':  header("Content-Type: image/png"); break;
+        }
 		echo Web::http(
 			'GET http://maps.google.com/maps/api/staticmap',
 			http_build_query(


### PR DESCRIPTION
in google chrome google map http://localhost/google/map is not showing maps, but only trash code. Headers are required.
