### PR TITLE
ICU minor fixes

### DIFF
--- a/lib/icu.php
+++ b/lib/icu.php
@@ -254,7 +254,7 @@ class ICU extends Base {
 		array_unshift($list,'en');
 		foreach (array_unique($list) as $language) {
 			$file=self::fixslashes(self::$vars['LOCALES']).$language.'.php';
-			if (is_file($file) && ($trans=require_once $file) &&
+			if (is_file($file) && ($trans=require $file) &&
 				is_array($trans))
 				// Combine dictionaries and assign key/value pairs
 				F3::mset($trans,'',FALSE);


### PR DESCRIPTION
Hi, here are 3 small fixes for the ICU class :
- the first one is concerning the auto-detect feature in the case where a browser is sending multiple language tags in the Accept-Language header: the boundary would then be a comma or a semi-colon. The fix also allows 2 letter tags (both "en" and "en-US" are correct). My browser was sending this header `da,fr;q=0.8,en-us;q=0.5,en;q=0.3` which was not understood.
- the second one is concerning the auto-detect feature in the case where a browser is not sending the Accept-Language header. In that case, we should restrict the language tag to 2 letters not to raise an "Undefined index" error when we read the $languages variable a few lines later. I noticed that problem on a bugged Safari which was not sending the header at all. The script was failing to terminate properly, trying to read `$languages['da_DK']`.
- the third one is about reloading dictionaries. Dictionaries are loaded whenever we change LOCALES or LANGUAGE. The require_once prevents the same dictionary to be loaded twice. This prevents that kind of code from working correctly :

```
F3::set('LANGUAGE','en');
//some code
F3::set('LANGUAGE','de');
//some code
F3::set('LANGUAGE','en');
//at that stage, the dictionary is still in german instead of english
```
