### PR TITLE
Fix autoload

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -1963,7 +1963,7 @@ class F3 extends Base {
 			for (;;) {
 				if ($glob=glob($auto.self::fixslashes($ns).'*')) {
 					$grep=preg_grep('/^'.preg_quote($auto,'/').
-						implode('[\/\.]',explode('\\',$ns.$iter)).
+						implode('[\/\._]',explode('\\',$ns.$iter)).
 						'(?:\.class)?\.php/i',$glob);
 					if ($file=current($grep)) {
 						unset($grep);


### PR DESCRIPTION
Enable flat file structure for namespaced classes using '_' as an namespace separator. As stated in docs.
