### PR TITLE
Bug fix #98 #99

### DIFF
--- a/lib/template.php
+++ b/lib/template.php
@@ -171,7 +171,8 @@ class F3markup extends Base {
 						}
 						$isfunc=isset($var[2]) && $var[2];
 						if (array_key_exists('_'.$match[1],$syms))
-							return '$_'.$self::remix($var[1]).
+							return '$_'.(strstr($var[1],'@')?
+								$self->expr('{{'.$var[1].'}}'):$self->remix($var[1])).
 								($isfunc?$self->expr('{{'.$var[2].'}}'):'');
 						$str='F3::get('.$self::stringify($var[1]).')';
 						$str='(F3::get(\'ESCAPE\')?'.


### PR DESCRIPTION
now this works:

```
    F3::set('section_pages',array(
        0=>array('name'=>'foo1'),
        1=>array('name'=>'foo2'),
        2=>array('name'=>'foo3'),
    ));
    F3::set('akey','name');
    echo Template::serve('test.html');
```

```
    <F3:repeat group="{{@section_pages}}" key="{{@key}}" value="{{@page}}">
      {{@page[@akey]}}<br />
    </F3:repeat>
```

also operations on the key var are possible, like `{{@section_pages[@key+1][@akey]}}`
