### PR TITLE
speed up factoring new axons

### DIFF
--- a/lib/db.php
+++ b/lib/db.php
@@ -457,8 +457,8 @@ class Axon extends Base {
 			@public
 	**/
 	function factory($row) {
-		$self=get_class($this);
-		$axon=new $self($this->table,$this->db,FALSE);
+		$axon=clone $this;
+		$axon->reset();
 		foreach ($row as $field=>$val) {
 			if (array_key_exists($field,$this->fields)) {
 				$axon->fields[$field]=$val;


### PR DESCRIPTION
this prevents asking the database everytime an axon is created. Clones the actual instance and resets before using it.
