### PR TITLE
RUN, add URI_SEGMENTS var

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -1290,6 +1290,8 @@ class F3 extends Base {
 		$req=preg_replace('/^'.preg_quote(self::$vars['BASE'],'/').
 			'\b(.+)/'.(self::$vars['CASELESS']?'i':''),'\1',
 			rawurldecode($_SERVER['REQUEST_URI']));
+		// store uri segments in f3 vars array for easy use in nav menus
+		self::$vars['URI_SEGMENTS'] = explode("/",$req);
 		foreach (self::$vars['ROUTES'] as $uri=>$route) {
 			if (!preg_match('/^'.
 				preg_replace(


### PR DESCRIPTION
add request URI segments to F3 var "URI_SEGMENTS" for easy access.

example usage would be for use in nav menu, when you need to know the first uri segment 
to highlight an item in nav menu

/pages/about
/pages/welcome
/pages/contact

if you use a 2 level nav menu system, you always want top level menu item label 'Pages' to be highlighted for the above pages etc.

i.e. example template psuedocode

repeat loop through nav menu li items
  if={{ nav_menu['link_p1']  == @URI_SEGMENT[1] }}
   apply css class for highlight
