### PR TITLE
Bug fix #91: overwriting symbol key with temporary var

### DIFF
--- a/lib/template.php
+++ b/lib/template.php
@@ -347,7 +347,8 @@ class F3markup extends Base {
 								}
 							}
 							unset($nval['@attrib']);
-							$this->syms['_'.$cvar]=eval('return '.$fstr.';');
+							if(!array_key_exists('_'.$cvar,$this->syms))
+								$this->syms['_'.$cvar]=eval('return '.$fstr.';');
 							$out.='<?php for ('.
 								'$_'.$cvar.'='.$fstr.';'.
 								'$_'.$cvar.'<='.$tstr.';'.


### PR DESCRIPTION
if loop uses a variable from symbol table, $fstr is not defined here, because it's only created when running the rendered template file. But $this->syms['_'.$cvar] was already added in the parent repead section, so it can be skipped if already defined.
