### PR TITLE
deliver the right lastInsertID in PostgreSQL

### DIFF
--- a/lib/db.php
+++ b/lib/db.php
@@ -743,7 +743,9 @@ class Axon extends Base {
 				$this->db->exec(
 					'INSERT INTO '.$this->table.' ('.$fields.') '.
 						'VALUES ('.$values.');',$bind);
-			$this->_id=$this->db->pdo->lastinsertid();
+			if(preg_match('/pgsql/',$this->db->backend))
+					$this->_id=$this->db->pdo->lastinsertid($this->table.'_'.end($this->pkeys).'_seq');
+			else    $this->_id=$this->db->pdo->lastinsertid();
 			if ($id)
 				$this->pkeys[$id]=$this->_id;
 		}


### PR DESCRIPTION
For the PGSQL PDO driver we need  to tell pdo->lastinsertid() the name of the sequence object, otherwise it returns FALSE. read more on http://php.net/manual/de/pdo.lastinsertid.php

The default seq object name syntax is "table_pkfield_seq" i.e.: "article_id_seq"
I used end($this->pkeys) to get the last key in that array, because if the current table has multiple primary keys, the order in pkeys is vice-versa the way they were defined. i.e. you'll add a pkey "version" later on, "version" will be the first element in that array. But in the most cases, the earliest pkey of a table is also the autoincremented pkey. So this end() thing is just an enhancement for multiple pk tables, and does not effect tables with a single primary key.

_cheers_
