### PR TITLE
Bug: F3::map class instantiation

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -1197,7 +1197,7 @@ class F3 extends Base {
 					$method.' '.$url,
 					$ref->isStatic()?
 						array($class,$func):
-						array(new $class,$func),
+						$class.'->'.$func,
 					$ttl,$throttle,$hotlink
 				);
 				unset($ref);


### PR DESCRIPTION
Can we remove class instantiation in F3::map ? It runs some business logic (__construct) before routing + decreases performance.
