### PR TITLE
add empty placeholders Profile STATS to match doc

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -1912,7 +1912,10 @@ class F3 extends Base {
 			// Profiler statistics
 			'STATS'=>array(
 				'MEMORY'=>array('start'=>memory_get_usage()),
-				'TIME'=>array('start'=>microtime(TRUE))
+				'TIME'=>array('start'=>microtime(TRUE)),
+                                'DB'=>array(),
+                                'FILES'=>array(),
+                                'CACHE'=>array()
 			),
 			// Temporary folder
 			'TEMP'=>'temp/',


### PR DESCRIPTION
docs make you expect to see all arrays, even if empty, this fixes that expectation. simples!
