### PR TITLE
BugFix #124 pgsql lastInsertId

### DIFF
--- a/lib/db.php
+++ b/lib/db.php
@@ -758,11 +758,12 @@ class Axon extends Base {
 				$this->db->exec(
 					'INSERT INTO '.$this->table.' ('.$fields.') '.
 						'VALUES ('.$values.');',$bind);
-			$this->_id=$this->db->pdo->lastinsertid(
-				preg_match('/pgsql/',$this->db->backend)?
-					($this->table.'_'.end($this->pkeys).'_seq'):
-					NULL
-			);
+			if (preg_match('/pgsql/', $this->db->backend)) {
+				$pklist = array_keys($this->pkeys);
+				$this->_id=$this->db->pdo->lastinsertid(
+					$this->table.'_'.end($pklist).'_seq');
+			} else
+				$this->_id=$this->db->pdo->lastinsertid();
 			if ($id)
 				$this->pkeys[$id]=$this->_id;
 		}


### PR DESCRIPTION
Sorry, i missed that `$this->pkeys` is an associative array. So `end($this->pkeys)` returns null instead of the field name. we need to get the array_keys first. Unfortunately chaining this in a single line with `end(array_keys($this->pkeys))` or `array_pop(array_keys($this->pkeys))` throws a 500 error "Only variables should be passed by reference". It works when using another temporarily variable in two lines.
