### PR TITLE
Bug fix: socket extension not required in Web class

### DIFF
--- a/lib/web.php
+++ b/lib/web.php
@@ -440,9 +440,6 @@ class Web extends Base {
 			@public
 	**/
 	static function onload() {
-		if (!extension_loaded('sockets'))
-			// Sockets extension required
-			trigger_error(sprintf(self::TEXT_PHPExt,'sockets'));
 		// Default translations
 		$diacritics=array(
 			'À'=>'A','Á'=>'A','Â'=>'A','Ã'=>'A','Å'=>'A','Ä'=>'A','Æ'=>'AE',


### PR DESCRIPTION
I think that the check for socket extension in Web class is not required.

I just installed F3 on a server where that extension is precisely not loaded and the **Web::http** method seems to work perfectly, although I get many times the error _PHP extension sockets is not enabled_ logged.
