### PR TITLE
BugFix: remain spaces minify, issue #163 #165 

### DIFF
--- a/gui/simple.css
+++ b/gui/simple.css
@@ -14,3 +14,8 @@ h1[name] span {
 .sprite {
 	background:url(./test.jpg) no-repeat;
 }
+@media(min-width:768px) and (max-width:979px){
+    body{
+        background:green;
+    }
+}

--- a/inc/main.php
+++ b/inc/main.php
@@ -3443,7 +3443,7 @@ class Main extends F3instance {
 			$this->set('QUIET',TRUE);
 			$text=Web::http('GET http://'.$_SERVER['HTTP_HOST'].$this->get('BASE').'/minified/simple.css');
 			$this->expect(
-				$text=='div *{text-align:center;}#content{border:1px #000 solid;text-shadow:#ccc -1px -1px 0px;}tr:nth-child(odd) td{line-height:1.2em;}h1[name] span{font-size:12pt;}.sprite{background:url(./test.jpg) no-repeat;}',
+				$text=='div *{text-align:center;}#content{border:1px #000 solid;text-shadow:#ccc -1px -1px 0px;}tr:nth-child(odd) td{line-height:1.2em;}h1[name] span{font-size:12pt;}.sprite{background:url(./test.jpg) no-repeat;}@media(min-width:768px) and (max-width:979px){body{background:green;}}',
 				'CSS minified properly - necessary (and IE-problematic) spaces preserved',
 				'CSS minified incorrectly: '.$this->stringify($text)
 			);

--- a/lib/web.php
+++ b/lib/web.php
@@ -145,18 +145,9 @@ class Web extends Base {
 			}
 			elseif (ctype_space($src[$ptr])) {
 				if ($ptr+1<strlen($src) && preg_match(
-					'/[\w'.($ext[1]=='css'?'+*#\.\-\)\]':'').']{2}/',
+					'/[\w'.($ext[1]=='css'?'+*#\.\-\(\)\]':'\$').']{2}/',
 					substr($dst,-1).$src[$ptr+1]))
 					$dst.=' ';
-				else {
-					$skip=($ext[1]=='js')?array('return'):array('and');
-					foreach ($skip as $w)
-						if ($ptr+1<strlen($src) &&
-							is_int(strpos($w,substr($dst,-strlen($w))))) {
-							$dst.=' ';
-							break;
-						}
-				}
 				$ptr++;
 			}
 			else {


### PR DESCRIPTION
fixes required spaces between `anyword $('foo')` in JS,jQuery
and before opening brackets outside of style definitions in css, used for media querys.
