### PR TITLE
Bug fix: If-Modifed-Since comparison with caching time

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -819,7 +819,7 @@ class Base {
 							$this->hive['URI']).'.url',$data);
 					if ($cached && $cached+$ttl>$now) {
 						if (!isset($req['If-Modified-Since']) ||
-							$cached>strtotime($req['If-Modified-Since'])) {
+							floor($cached)>strtotime($req['If-Modified-Since'])) {
 							// Retrieve from cache backend
 							list($headers,$body)=$data[0];
 							if (PHP_SAPI!='cli')


### PR DESCRIPTION
I think that the caching time should be converted to integer before being compared with the value of the _If-Modified-Since_ header since the latter doesn't hold the microseconds precision.

Otherwise, we'll nearly never run the _HTTP client-cached page is fresh_ code (the one generating the 304 status).
