### PR TITLE
Bug fix: filter returns records where the filtered field does not exist

### DIFF
--- a/lib/db/jig/mapper.php
+++ b/lib/db/jig/mapper.php
@@ -177,7 +177,9 @@ class Mapper extends \DB\Cursor {
 					$_expr='';
 					$ctr=0;
 					$named=FALSE;
-					foreach ($tokens as $token) {
+					$_prev_expr='';
+					for($i=0,$max=count($tokens);$i<$max;$i++) {
+						$token = $tokens[$i];
 						if (is_string($token))
 							if ($token=='?') {
 								// Positional
@@ -197,6 +199,17 @@ class Mapper extends \DB\Cursor {
 							$named=FALSE;
 						}
 						else {
+							// check field existence
+							if($token[1][0]=='$') {
+								$chk='isset('.$token[1].')';
+								if ($_prev_expr=='preg_match') {
+									$_expr.=$token[1].$tokens[++$i].' && '.$chk;
+									$_prev_expr='';
+									continue;
+								} else
+									$_expr.=$chk.' && ';
+							}
+							$_prev_expr=$token[1];
 							$_expr.=$token[1];
 							continue;
 						}


### PR DESCRIPTION
When you do a filter like num2 < 5 ... then Jig also returns records, where num2 is not defined.
before #230 we had some isset() checks in the $_expr, after #230 you kicked them and solved the undefined var issue by adding default null values for those fields to the scope (with that extract($_row+$_add); thing), which is as good solution IMO. But comparing the results with SQL or Mongo now revealed, that Jigs return also contains records where the field, which was searched for, is not existing. To solve that, i added the isset() checks again (now in a better version than in my #230 approach)

it transforms $_expr like
`$num2 <= 1`
to
`isset($num2) && $num2 <= 1`

and filters like
`( $num2 < 2 AND $num1 > 1 ) OR preg_match('/o9$/',$title)`
to
`( isset($num2) && $num2 < 2 AND isset($num1) && $num1 > 1 ) OR preg_match('/o9$/',$title) && isset($title)`

i hope you like it.
cheers
