### PR TITLE
Bug fix: Image dump/render additional arguments shifted

### DIFF
--- a/app/image.php
+++ b/app/image.php
@@ -161,6 +161,12 @@ class Image extends Controller {
 			'<img src="'.$src.'" '.
 				'title="'.$img->width().'x'.$img->height().'" />'
 		);
+		$test->expect(
+			$src=$f3->base64($img->restore()->dump('png',NULL,9,PNG_ALL_FILTERS),'image/png'),
+			'Dump with additional arguments<br />'.
+			'<img src="'.$src.'" '.
+				'title="'.$img->width().'x'.$img->height().'" />'
+		);
 		unset($img);
 		$f3->set('ESCAPE',FALSE);
 		$f3->set('results',$test->results());

--- a/lib/image.php
+++ b/lib/image.php
@@ -411,7 +411,7 @@ class Image {
 			header('Content-Type: image/'.$format);
 			header('X-Powered-By: '.Base::instance()->get('PACKAGE'));
 		}
-		call_user_func_array('image'.$format,array($this->data)+$args);
+		call_user_func_array('image'.$format,array_merge(array($this->data),$args));
 	}
 
 	/**
@@ -422,7 +422,7 @@ class Image {
 		$args=func_get_args();
 		$format=$args?array_shift($args):'png';
 		ob_start();
-		call_user_func_array('image'.$format,array($this->data)+$args);
+		call_user_func_array('image'.$format,array_merge(array($this->data),$args));
 		return ob_get_clean();
 	}
 


### PR DESCRIPTION
The following syntaxes were not working because of shifted arguments:

```
$img->dump('png',NULL,9,PNG_ALL_FILTERS);
$img->render('jpeg',NULL,50);
$img->render('jpeg',$target,50);
```
