### PR TITLE
Bug fix: cached body not echoed

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -1078,6 +1078,9 @@ final class Base {
 						if (PHP_SAPI!='cli')
 							array_walk($headers,'header');
 						$this->expire($cached+$ttl-$now);
+						if (!$this->hive['QUIET'])
+							echo $body;
+						die();
 					}
 					else
 						// Expire HTTP client-cached page


### PR DESCRIPTION
When a route is cached, we rerun the route handler instead of just outputting the cached response.
