### PR TITLE
Allow user to control whether Base::reroute() uses a permanent redirect

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -950,16 +950,18 @@ final class Base {
 	}
 
 	/**
-		Reroute to specified URI
+		Reroute to specified URI.  This is by default a temporary (303) redirect,
+		but can be made permanent (301).
 		@return NULL
 		@param $uri string
+		@param $permanent boolean
 	**/
-	function reroute($uri) {
+	function reroute($uri, $permanent=FALSE) {
 		if (PHP_SAPI!='cli') {
 			@session_commit();
 			header('Location: '.(preg_match('/^https?:\/\//',$uri)?
 				$uri:($this->hive['BASE'].$uri)));
-			$this->status($this->hive['VERB']=='GET'?301:303);
+			$this->status($permanent?301:303);
 			die;
 		}
 		$this->mock('GET '.$uri);


### PR DESCRIPTION
In a lot of cases when using GET, you don't want a permanent redirect, e.g. when someone tries to access your admin interface and you redirect them to a login page.  With a permanent redirect if you try to visit these pages again once logged in you'll get sent back to the login page.
