### PR TITLE
Bug fix: Web\Rss error when not enough items in the feed

### DIFF
--- a/lib/web.php
+++ b/lib/web.php
@@ -637,7 +637,7 @@ class Web extends Prefab {
 		$out=array();
 		if (isset($xml->channel)) {
 			$out['source']=(string)$xml->channel->title;
-			for ($i=0;$i<$max;$i++) {
+			for ($i=0;$i<min($max,count($xml->channel->item));$i++) {
 				$item=$xml->channel->item[$i];
 				$list=array(''=>NULL)+$item->getnamespaces(TRUE);
 				$fields=array();


### PR DESCRIPTION
We get an error if we retrieve a feed which contains less entries than the `$max` parameter.
E.g:

```
$web=\Web::instance();
$url='http://mydomain.tld/rss';//Feed containing 20 entries
$web->rss($url,30);//<< Fatal error
```
