### PR TITLE
Suggestion: currency formatting improvement

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -640,6 +640,8 @@ final class Base {
 												$args[$pos],0,'',
 												$conv['thousands_sep']);
 									case 'currency':
+										if (function_exists('money_format'))
+											return money_format('%n',$args[$pos]);
 										$conv+=array(
 											'sign'=>$args[$pos]<0?$conv['negative_sign']:$conv['positive_sign'],
 											'cs_precedes'=>$args[$pos]<0?$conv['n_cs_precedes']:$conv['p_cs_precedes'],


### PR DESCRIPTION
Hi, the currency format functionnality should be improved to fit all the possible configurations. For example, here are the values returned by `{{@price,-12.95|format}}` for a few different locales, compared with `money_format` results:

<table>
<tr><th>Locale</th><th>Fat-free format</th><th>PHP money_format</th></tr>
<tr><td>en_US</td><td>$-12.95</td><td>-$12.95</td></tr>
<tr><td>fr_FR</td><td>€-12,95</td><td>-12,95 €</td></tr>
<tr><td>ru_RU</td><td>руб-12,95</td><td>-12,95 руб</td></tr>
<tr><td>da_DK</td><td>kr-12,95</td><td>kr -12,95</td></tr>
</table>


I added support to the code, following what is defined in the C99 standard. Test script [here](http://534f.de/TFg2Xj6V).
Optionally we can use `money_format` if available.
