### PR TITLE
fix sql performance for cleaning up old sessions

### DIFF
--- a/lib/db/sql/session.php
+++ b/lib/db/sql/session.php
@@ -82,7 +82,7 @@ class Session extends Mapper {
 	*	@param $max int
 	**/
 	function cleanup($max) {
-		$this->erase('stamp+'.$max.'<'.time());
+		$this->erase('stamp<'.(time()-$max));
 		return TRUE;
 	}
 


### PR DESCRIPTION
for better performance avoid calculating the time for every record, instead calculate the compared time once.
