### PR TITLE
more extensive sql identifier quotation

### DIFF
--- a/lib/db/sql.php
+++ b/lib/db/sql.php
@@ -197,7 +197,7 @@ class SQL extends \PDO {
 				'PRAGMA table_info('.$table.');',
 				'name','type','dflt_value','notnull',0,'pk',1),
 			'mysql'=>array(
-				'SHOW columns FROM `'.$this->dbname.'`.'.$table.';',
+				'SHOW columns FROM `'.$this->dbname.'`.`'.$table.'`;',
 				'Field','Type','Default','Null','YES','Key','PRI'),
 			'mssql|sqlsrv|sybase|dblib|pgsql|odbc'=>array(
 				'SELECT '.
@@ -279,6 +279,25 @@ class SQL extends \PDO {
 	**/
 	function name() {
 		return $this->dbname;
+	}
+
+	/**
+	*	Return quoted identifier name
+	*	@param $key
+	*	@return array
+	**/
+	function quoteKey($key) {
+		if ($this->engine=='mysql')
+			$key="`".$key."`";
+		elseif (preg_match('/sybase|dblib|odbc/',$this->engine))
+			$key="'".$key."'";
+		elseif (preg_match('/sqlite2?|pgsql/',$this->engine))
+			$key='"'.$key.'"';
+		elseif (preg_match('/mssql|sqlsrv/',$this->engine))
+			$key="[".$key."]";
+		elseif ($this->engine=='oci')
+			$key='"'.strtoupper($key).'"';
+		return $key;
 	}
 
 	/**

--- a/lib/db/sql/mapper.php
+++ b/lib/db/sql/mapper.php
@@ -236,9 +236,7 @@ class Mapper extends \DB\Cursor {
 		);
 		$adhoc='';
 		foreach ($this->adhoc as $key=>$field)
-			$adhoc.=','.$field['expr'].' AS '.
-				(preg_match('/mysql|sqlite/',$this->engine)?
-					('`'.$key.'`'):$key);
+			$adhoc.=','.$field['expr'].' AS '.$this->db->quoteKey($key);
 		return $this->select('*'.$adhoc,$filter,$options,$ttl);
 	}
 
@@ -307,9 +305,7 @@ class Mapper extends \DB\Cursor {
 					$inc=$key;
 			}
 			if ($field['changed'] && $key!=$inc) {
-				$fields.=($ctr?',':'').
-					(preg_match('/mysql|sqlite/',$this->engine)?
-						('`'.$key.'`'):$key);
+				$fields.=($ctr?',':'').$this->db->quoteKey($key);
 				$values.=($ctr?',':'').'?';
 				$args[$ctr+1]=array($field['value'],$field['pdo_type']);
 				$ctr++;
@@ -331,7 +327,7 @@ class Mapper extends \DB\Cursor {
 			$query='';
 			$args='';
 			foreach ($pkeys as $pkey) {
-				$query.=($query?' AND ':'').$pkey.'=?';
+				$query.=($query?' AND ':'').$this->db->quoteKey($pkey).'=?';
 				$args[$ctr+1]=$this->fields[$pkey]['value'];
 				$ctr++;
 			}
@@ -353,15 +349,13 @@ class Mapper extends \DB\Cursor {
 		$filter='';
 		foreach ($this->fields as $key=>$field)
 			if ($field['changed']) {
-				$pairs.=($pairs?',':'').
-					(preg_match('/mysql|sqlite/',$this->engine)?
-						('`'.$key.'`'):$key).'=?';
+				$pairs.=($pairs?',':'').$this->db->quoteKey($key).'=?';
 				$args[$ctr+1]=array($field['value'],$field['pdo_type']);
 				$ctr++;
 			}
 		foreach ($this->fields as $key=>$field)
 			if ($field['pkey']) {
-				$filter.=($filter?' AND ':'').$key.'=?';
+				$filter.=($filter?' AND ':'').$this->db->quoteKey($key).'=?';
 				$args[$ctr+1]=array($field['previous'],$field['pdo_type']);
 				$ctr++;
 			}
@@ -396,9 +390,7 @@ class Mapper extends \DB\Cursor {
 		$filter='';
 		foreach ($this->fields as $key=>&$field) {
 			if ($field['pkey']) {
-				$filter.=($filter?' AND ':'').
-					(preg_match('/mysql|sqlite/',$this->engine)?
-						('`'.$key.'`'):$key).'=?';
+				$filter.=($filter?' AND ':'').$this->db->quoteKey($key).'=?';
 				$args[$ctr+1]=array($field['previous'],$field['pdo_type']);
 				$ctr++;
 			}
@@ -482,9 +474,7 @@ class Mapper extends \DB\Cursor {
 	function __construct(\DB\SQL $db,$table,$ttl=60) {
 		$this->db=$db;
 		$this->engine=$db->driver();
-		if (preg_match('/mysql|sqlite/',$this->engine))
-			$table='`'.$table.'`';
-		$this->table=$table;
+		$this->table=$this->db->quoteKey($table);
 		$this->fields=$db->schema($table,$ttl);
 		$this->reset();
 	}


### PR DESCRIPTION
I added some more quotes around table and column identifiers, using a more suitable and reusable new function. I think this will work better against hitting preserved words and special chars in their names (even if i would never ever recommend using them).

I setup the following quotations:
**MySQL**: backticks (`)
http://dev.mysql.com/doc/refman/5.0/en/identifier-qualifiers.html

**SQlite**: double-quotes (") (better than backticks)
http://www.sqlite.org/lang_keywords.html

**PostgreSQL**: double-quotes (")
http://www.postgresql.org/docs/8.2/static/sql-syntax-lexical.html

**MS SQL, SQL Server**: brackets ( [ ] )
http://stackoverflow.com/questions/695578/creating-table-names-that-are-reserved-words-keywords-in-ms-sql-server

**Oracle**: (if we add this someday) double-quotes (") and uppercase
http://stackoverflow.com/questions/563090/oracle-what-exactly-do-quotation-marks-around-the-table-name-do

**TransactSQL**: for the rest like sybase,dblib,odbc: single-quotes (')

I tested these changes with mysql, sqlite and postgre, using the F3 sql and my schemabuilder unit tests.
