### PR TITLE
custom onerror for each code

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -904,6 +904,10 @@ final class Base {
 		if ($this->hive['ONERROR'])
 			// Execute custom error handler
 			$this->call($this->hive['ONERROR'],$this);
+		if ($this->hive['ONERROR-'.$code])
+			// Execute custom error handler
+			$this->call($this->hive['ONERROR-'.$code],$this);
+
 		elseif (!$prior && PHP_SAPI!='cli' && !$this->hive['QUIET'])
 			echo $this->hive['AJAX']?
 				json_encode($this->hive['ERROR']):


### PR DESCRIPTION
$f3->set('ONERROR-403', function($f3){
 // -------------------------- error stuff here for "forbidden" ------------------------
 });
$f3->set('ONERROR-404', function($f3){
 // -------------------------- error stuff here for "page cannot be found" ------------------------
 });

its nasty.. but works ok in all my tests / project. reason for this... i want the default f3 behavior for errors except for 403 and maybe 404 later on
