### PR TITLE
Suggestion: Template <switch> directive

### DIFF
--- a/app/template.php
+++ b/app/template.php
@@ -200,7 +200,7 @@ class Template extends Controller {
 		$f3->set('test',array('string'=>'thin','int'=>123,'bool'=>FALSE));
 		$test->expect(
 			preg_replace('/\s/','',$tpl->render('templates/test11.htm'))==
-				'<em>thin</em>-1failed',
+				'<em>thin</em>-1failed123124',
 			'<switch>, <case>, <default>'
 		);
 		$f3->clear('test');

--- a/lib/template.php
+++ b/lib/template.php
@@ -219,7 +219,7 @@ class Template extends View {
 		return
 			'<?php case '.$this->token($attrib['value']).': ?>'.
 				$this->build($node).
-			'<?php break; ?>';
+			'<?php '.(isset($attrib['break'])?'if ('.$this->token($attrib['break']).') ':'').'break; ?>';
 	}
 
 	/**
@@ -230,7 +230,7 @@ class Template extends View {
 	protected function _default(array $node) {
 		return
 			'<?php default: ?>'.
-				$this->build($node);
+				$this->build($node).
 			'<?php break; ?>';
 	}
 

--- a/ui/templates/test11.htm
+++ b/ui/templates/test11.htm
@@ -3,12 +3,18 @@
 	<case value="'thin'"><em>thin</em></case>
 </switch>
 <switch expr="{{@test.int}}">
+	<default>-1</default>
 	<case value="100">100</case>
 	<case value="200">200</case>
 	<case value="300">300</case>
-	<default>-1</default>
 </switch>
 <switch expr="1">
 	<case value="{{@test.bool===TRUE}}">passed</case>
 	<case value="{{@test.bool===FALSE}}">failed</case>
+</switch>
+<switch expr="{{@test.int}}">
+	<case value="123" break="false">123</case>
+	<case value="124" break="true">124</case>
+	<case value="125" break="false">125</case>
+	<default>-1</default>
 </switch>


### PR DESCRIPTION
Here's a suggestion to add a `<switch>` directive to the Template class. It would be used like this:

```
<switch expr="{{@myvar}}">
  <case value="123">
    ...
  </case>
  <case value="{{@anothervar}}">
    ...
  </case>
  <case value="'a string'">
    ...
  </case>
  <default>
    ...
  </default>
</switch>
```

There's one flaw in the provided code though: unquoted strings in `<case>` directives lead to an error.
