### PR TITLE
Fix language detecting under Windows

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -737,7 +737,7 @@ final class Base {
 				$parts=explode('_',$locale);
 				$locale=@constant('ISO::LC_'.$parts[0]);
 				if (isset($parts[1]) &&
-					$country=@constant('ISO::CC_'.$parts[1]))
+					$country=@constant('ISO::CC_'.strtolower($parts[1])))
 					$locale.='_'.$country;
 			}
 			$this->locales[]=$locale;


### PR DESCRIPTION
The language detecting under Windows can crash, if the country part is UPPERCASE but the ISO:CC_ constant is lower case. (For example "ISO:CC_DE" vs. "ISO:CC_de")

Happens under a German Windows with PHP 5.3.1
