### PR TITLE
Remove unnecessary 'Return' statement

### DIFF
--- a/lib/web.php
+++ b/lib/web.php
@@ -9,7 +9,6 @@
 	ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
 	IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR
 	PURPOSE.
-
 	Please see the license.txt file for more information.
 */
 
@@ -193,7 +192,6 @@ class Web extends Prefab {
 						!move_uploaded_file($file['tmp_name'],$dst))
 						return FALSE;
 				}
-				return TRUE;
 			}
 		return FALSE;
 	}


### PR DESCRIPTION
Inside receive() there is an unnecessary 'return true' statement that caused the loop to terminate even when there were more items in the $_FILES array.

That way you can have many input[type=file] in a form and upload them all with a single $web->receive() call.

Greetings,
KB
