### PR TITLE
mapping to first and last record in cursor.

### DIFF
--- a/lib/db/cursor.php
+++ b/lib/db/cursor.php
@@ -107,19 +107,19 @@ abstract class Cursor extends \Magic {
 	}
 
 	/**
-	*	Move pointer to first record in cursor
+	*	Map to first record in cursor
 	*	@return mixed
 	**/
 	function first() {
-		return $this->query[$this->ptr=0];
+		return $this->skip(-$this->ptr);
 	}
 
 	/**
-	*	Move pointer to last record in cursor
+	*	Map to last record in cursor
 	*	@return mixed
 	**/
 	function last() {
-		return $this->query[$this->ptr=($ctr=count($this->query))?$ctr-1:0];
+		return $this->skip(($ofs=count($this->query)-$this->ptr)?$ofs-1:0);
 	}
 
 	/**


### PR DESCRIPTION
When we use `$mapper->last()` it will move the pointer to the last record, yes and returns that mapper object correctly. But it misses to make that record the active document for the mapper itself. This done by `skip()` in all mapper implemantations of Jig, SQL, and Mongo Mapper... but since Cursor `last()` and `first()` are just moving the pointer instead of skipping to them, the active ducoment stays the same, even if the pointer has moved.

This fix now uses skip to move and map to the last and first record of a cursor set.
