### PR TITLE
modified the Nginx config and removed uselesss lines

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -271,12 +271,10 @@ server {
     root /var/www/html;
     location / {
         index index.php index.html index.htm;
-        try_files $uri /index.php;
+        try_files $uri $uri/ /index.php?$query_string;
     }
     location ~ \.php$ {
         fastcgi_pass ip_address:port;
-        fastcgi_index index.php;
-        fastcgi_param SCRIPT_FILENAME $document_root/$fastcgi_script_name;
         include fastcgi_params;
     }
 }


### PR DESCRIPTION
The main change is the added `?$query_string` which also fixes issues with urls like `example.org/search?q=foo`. 
