### PR TITLE
Trim the callback handler in the route function

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -978,7 +978,7 @@ final class Base {
 			if (!preg_match('/'.self::VERBS.'/',$verb))
 				$this->error(501,$verb.' '.$this->hive['URI']);
 			$this->hive['ROUTES'][str_replace('@',"\x00".'@',$parts[2])]
-				[$type][strtoupper($verb)]=array($handler,$ttl,$kbps);
+				[$type][strtoupper($verb)]=array(trim($handler),$ttl,$kbps);
 		}
 	}
 


### PR DESCRIPTION
By trimmer the callback variable in the route function we prevent the
system for giving a 404 page on trailing whitespaces. This might happen
by accident in .ini files.
