### PR TITLE
option for simply just count the db->log entries.

### DIFF
--- a/lib/db/jig.php
+++ b/lib/db/jig.php
@@ -30,7 +30,7 @@ class Jig {
 		//! Current storage format
 		$format,
 		//! Jig log
-		$log;
+		$log=array();
 
 	/**
 	*	Read data from file
@@ -74,11 +74,12 @@ class Jig {
 	}
 
 	/**
-	*	Return SQL profiler results
+	*	Return JIG profiler results
+	*	@param bool $count
 	*	@return string
-	**/
-	function log() {
-		return $this->log;
+	*/
+	function log($count=false) {
+		return $count?count($this->log):implode($this->log);
 	}
 
 	/**
@@ -88,7 +89,7 @@ class Jig {
 	**/
 	function jot($frame) {
 		if ($frame)
-			$this->log.=date('r').' '.$frame.PHP_EOL;
+			$this->log[]=date('r').' '.$frame.PHP_EOL;
 	}
 
 	/**

--- a/lib/db/mongo.php
+++ b/lib/db/mongo.php
@@ -25,17 +25,18 @@ class Mongo extends \MongoDB {
 
 	private
 		//! MongoDB log
-		$log;
+		$log=array();
 
 	/**
 	*	Return MongoDB profiler results
+	*	@param bool $count
 	*	@return string
 	**/
-	function log() {
+	function log($count=false) {
 		$cursor=$this->selectcollection('system.profile')->find();
 		foreach (iterator_to_array($cursor) as $frame)
 			if (!preg_match('/\.system\..+$/',$frame['ns']))
-				$this->log.=date('r',$frame['ts']->sec).' ('.
+				$this->log[]=date('r',$frame['ts']->sec).' ('.
 					sprintf('%.1f',$frame['millis']).'ms) '.
 					$frame['ns'].' ['.$frame['op'].'] '.
 					(empty($frame['query'])?
@@ -43,7 +44,7 @@ class Mongo extends \MongoDB {
 					(empty($frame['command'])?
 						'':json_encode($frame['command'])).
 					PHP_EOL;
-		return $this->log;
+		return $count?count($this->log):implode($this->log);
 	}
 
 	/**

--- a/lib/db/sql.php
+++ b/lib/db/sql.php
@@ -28,7 +28,7 @@ class SQL extends \PDO {
 		//! Number of rows affected by query
 		$rows=0,
 		//! SQL log
-		$log;
+		$log=array();
 
 	/**
 	*	Begin SQL transaction
@@ -162,7 +162,7 @@ class SQL extends \PDO {
 				}
 			}
 			if ($log)
-				$this->log.=date('r').' ('.
+				$this->log[]=date('r').' ('.
 					sprintf('%.1f',1e3*(microtime(TRUE)-$now)).'ms) '.
 					preg_replace($keys,$vals,$cmd,1).PHP_EOL;
 		}
@@ -181,10 +181,11 @@ class SQL extends \PDO {
 
 	/**
 	*	Return SQL profiler results
+	*	@param bool $count
 	*	@return string
-	**/
-	function log() {
-		return $this->log;
+	*/
+	function log($count=false) {
+		return $count?count($this->log):implode($this->log);
 	}
 
 	/**


### PR DESCRIPTION
This addition enables you to just count the logged entries in the db profiler, so `$db->log( true );` will return the number of executed queries, instead of all the log as string.

requested at the google group https://groups.google.com/d/msg/f3-framework/REUl8Uq3l6o/OIAmYW7zhDYJ
