### PR TITLE
Suggestion: proposed change to filler

### DIFF
--- a/lib/web.php
+++ b/lib/web.php
@@ -743,38 +743,21 @@ class Web extends Prefab {
 	*	Return chunk of text from standard Lorem Ipsum passage
 	*	@return string
 	*	@param $count int
-	*	@param $max int
-	*	@param $std bool
 	**/
-	function filler($count=1,$max=20,$std=TRUE) {
-		$out='';
-		if ($std)
-			$out='Lorem ipsum dolor sit amet, consectetur adipisicing elit, '.
-				'sed do eiusmod tempor incididunt ut labore et dolore magna '.
-				'aliqua.';
-		$rnd=explode(' ',
-			'a ab ad accusamus adipisci alias aliquam amet animi aperiam '.
-			'architecto asperiores aspernatur assumenda at atque aut beatae '.
-			'blanditiis cillum commodi consequatur corporis corrupti culpa '.
-			'cum cupiditate debitis delectus deleniti deserunt dicta '.
-			'dignissimos distinctio dolor ducimus duis ea eaque earum eius '.
-			'eligendi enim eos error esse est eum eveniet ex excepteur '.
-			'exercitationem expedita explicabo facere facilis fugiat harum '.
-			'hic id illum impedit in incidunt ipsa iste itaque iure iusto '.
-			'laborum laudantium libero magnam maiores maxime minim minus '.
-			'modi molestiae mollitia nam natus necessitatibus nemo neque '.
-			'nesciunt nihil nisi nobis non nostrum nulla numquam occaecati '.
-			'odio officia omnis optio pariatur perferendis perspiciatis '.
-			'placeat porro possimus praesentium proident quae quia quibus '.
-			'quo ratione recusandae reiciendis rem repellat reprehenderit '.
-			'repudiandae rerum saepe sapiente sequi similique sint soluta '.
-			'suscipit tempora tenetur totam ut ullam unde vel veniam vero '.
-			'vitae voluptas');
-		for ($i=0,$add=$count-(int)$std;$i<$add;$i++) {
-			shuffle($rnd);
-			$words=array_slice($rnd,0,mt_rand(3,$max));
-			$out.=' '.ucfirst(implode(' ',$words)).'.';
-		}
+	function filler($count=125) {
+		$out="";
+		$fill="Lorem ipsum dolor sit amet, consectetur adipisicing elit, " .
+                        "sed do eiusmod tempor incididunt ut labore et dolore magna " . 
+                        "aliqua. Ut enim ad minim veniam, quis nostrud exercitation " .
+                        "ullamco laboris nisi ut aliquip ex ea commodo consequat. " .
+                        "Duis aute irure dolor in reprehenderit in voluptate velit " .
+                        "esse cillum dolore eu fugiat nulla pariatur. Excepteur sint " .
+                        "occaecat cupidatat non proident, sunt in culpa qui officia " .
+                        "deserunt mollit anim id est laborum. ";
+                do {$out .= $fill; }
+                    while (strlen($out) < $count);
+
+                $out = substr($out,0,$count);
 		return $out;
 	}
 


### PR DESCRIPTION
specify count (length) of string to be generated, since typical text blocks (layouts) use length limits (i.e. Headline 125 characters). Use of previous version specifying count of words too hard to determine how to fit within layout block (i.e. headline). This revision just generates filler up to max count, no cpu cycles wasted on exploding, randomizing and imploding commands, since filler is only temp for layout visualization & repeated passages shouldn't bother anyone ;)
