### PR TITLE
Suggestion: A new function for the bcrypt plugin.

### DIFF
--- a/lib/bcrypt.php
+++ b/lib/bcrypt.php
@@ -22,6 +22,11 @@ class Bcrypt extends Prefab {
 		E_Salt='Invalid salt (must be at least 22 alphanumeric characters)';
 	//@}
 
+	//@{ Cost
+	const 
+		Cost=10;
+	//@}
+	
 	/**
 	*	Generate bcrypt hash of string
 	*	@return string|FALSE
@@ -29,7 +34,7 @@ class Bcrypt extends Prefab {
 	*	@param $salt string
 	*	@param $cost int
 	**/
-	function hash($pw,$salt=NULL,$cost=10) {
+	function hash($pw,$salt=NULL,$cost=self::Cost) {
 		if ($cost<4 || $cost>31)
 			trigger_error(self::E_Cost);
 		$len=22;
@@ -71,4 +76,19 @@ class Bcrypt extends Prefab {
 		return $out===0;
 	}
 
+	/**
+	 * Verify Password if Password is still strong enough (Costs)
+	 * @param $hash string
+	 * @param $cost int
+	 * @return bool
+	 */
+	function password_needs_rehash($hash, $cost=self::Cost)
+	{
+		list($pwcost) = sscanf($hash, "$2y$%d$");
+		if ($pwcost != $cost)
+			return true;
+		else
+			return false;
+	}
+	
 }


### PR DESCRIPTION
Hi,

i added a new function to the bcrypt plugin.
It checks if a password needs to be rehashed.
This becomes relevant when you want to increase the costs to make bcrypt even harder to crack.

The new function allows you to do something like that:

``` php
// define the new cost
$cost=15;
if ($bcrypt->verify($pw,$hash)==true)
        {
            if ($bcrypt->password_needs_rehash($hash, $cost))
            {
                $hash=$bcrypt->hash($pw,null,$cost);
                // Save the new hash in the db 
            }
        }
```

if you add this code to the login, the passwords will be rehashed automatically if needed.
You only have to change the $cost variable and you're done :)

Since there are now 2 places which define the default cost i added a constant for it.

I hope this function helps someone :)

kind regards,
Haynes
