### PR TITLE
[Jig Mapper] erase filter malfunction

### DIFF
--- a/lib/db/jig/mapper.php
+++ b/lib/db/jig/mapper.php
@@ -334,11 +334,9 @@ class Mapper extends \DB\Cursor {
 		$db=$this->db;
 		$now=microtime(TRUE);
 		$data=$db->read($this->file);
-		if ($filter) {
-			$data=$this->find($filter,NULL,FALSE);
-			foreach (array_keys(array_reverse($data)) as $id)
-				unset($data[$id]);
-		}
+		if ($filter)
+			foreach ($this->find($filter, NULL, FALSE) as $mapper)
+				unset($data[$mapper->_id]);
 		elseif (isset($this->id)) {
 			unset($data[$this->id]);
 			parent::erase();


### PR DESCRIPTION
Having a `$filter` condition set for the erase method, caused the whole data table to be dropped / overwritten, regardless of the filtered results.
I simplified and fixed this in the attached commit.
