### PR TITLE
page limit in paginate return

### DIFF
--- a/lib/db/cursor.php
+++ b/lib/db/cursor.php
@@ -90,6 +90,7 @@ abstract class Cursor extends \Magic {
 				)
 			),
 			'total'=>$total,
+			'limit'=>$size,
 			'count'=>$count,
 			'pos'=>$pos<$count?$pos:0
 		);


### PR DESCRIPTION
it would be nice to pass-through the max $size of a subset in the returned array, as you might need it for displaying pagebrowser stuff and this way you don't need to pass that limit value again separately to template by yourself.
