### PR TITLE
Basic auth REDIRECT_HTTP_AUTHORIZATION support

### DIFF
--- a/lib/auth.php
+++ b/lib/auth.php
@@ -190,10 +190,12 @@ class Auth {
 	function basic($func=NULL) {
 		$fw=Base::instance();
 		$realm=$fw->get('REALM');
-		if (isset($_SERVER['HTTP_AUTHORIZATION']))
+		if (isset($_SERVER['HTTP_AUTHORIZATION'])||isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION']))
 			list($_SERVER['PHP_AUTH_USER'],$_SERVER['PHP_AUTH_PW'])=
 				explode(':',base64_decode(
-					substr($_SERVER['HTTP_AUTHORIZATION'],6)));
+					substr(isset($_SERVER['HTTP_AUTHORIZATION'])?
+						$_SERVER['HTTP_AUTHORIZATION']:
+						$_SERVER['REDIRECT_HTTP_AUTHORIZATION'],6)));
 		if (isset($_SERVER['PHP_AUTH_USER'],$_SERVER['PHP_AUTH_PW']) &&
 			$this->login(
 				$_SERVER['PHP_AUTH_USER'],


### PR DESCRIPTION
Hi,
in .htaccess, we use the flag `E=HTTP_AUTHORIZATION:%{HTTP:Authorization}` to transfer basic auth credentials to PHP when it is running as CGI/FCGI.
Depending on the Apache configuration, the authorization string is copied either to `$_SERVER['HTTP_AUTHORIZATION']` or to `$_SERVER['REDIRECT_HTTP_AUTHORIZATION']`. We should support this in `$auth->basic`.
