### PR TITLE
NEW: Image->captcha color parameters

### DIFF
--- a/app/image.php
+++ b/app/image.php
@@ -23,6 +23,20 @@ class Image extends Controller {
 				'CAPTCHA<br />'.
 				'<img src="'.$src.'" title="CAPTCHA" />'
 			);
+                        $test->expect(
+                                $src=$f3->base64(
+                                        $img->captcha('fonts/thunder.ttf',24,5,NULL,'',0xFFF000,0x000FFF)->
+                                        dump(),'image/png'),
+                                'Custom color CAPTCHA<br />'.
+                                '<img src="'.$src.'" title="CAPTCHA" />'
+                        );
+                        $test->expect(
+                                $src=$f3->base64(
+                                        $img->captcha('fonts/thunder.ttf',24,5,NULL,'',array(0xFF0000,0x00AA00,0X555555,0xAAAAAA),array(0x0000AA,0xFFFFFF))->
+                                        dump(),'image/png'),
+                                'Random color CAPTCHA<br />'.
+                                '<img src="'.$src.'" title="CAPTCHA" />'
+                        );
 			$test->expect(
 				$src=$f3->base64(
 					$img->identicon(md5(mt_rand()),48)->dump(),'image/png'),

--- a/lib/image.php
+++ b/lib/image.php
@@ -367,7 +367,7 @@ class Image {
 	*	@param $key string
 	*	@param $path string
 	**/
-	function captcha($font,$size=24,$len=5,$key=NULL,$path='') {
+	function captcha($font,$size=24,$len=5,$key=NULL,$path='',$bg=0x000000,$color=0xFFFFFF) {
 		$fw=Base::instance();
 		foreach ($fw->split($path?:$fw->get('UI')) as $dir)
 			if (is_file($path=$dir.$font)) {
@@ -380,10 +380,10 @@ class Image {
 					$w=$box[2]-$box[0];
 					$h=$box[1]-$box[5];
 					$char=imagecreatetruecolor($block,$block);
-					imagefill($char,0,0,0);
+					imagefill($char,0,0,is_array($bg)?$bg[array_rand($bg)]:$bg);
 					imagettftext($char,$size*2,0,
 						($block-$w)/2,$block-($block-$h)/2,
-						0xFFFFFF,$path,$seed[$i]);
+						is_array($color)?$color[array_rand($color)]:$color,$path,$seed[$i]);
 					$char=imagerotate($char,mt_rand(-30,30),
 						imagecolorallocatealpha($char,0,0,0,127));
 					// Reduce to normal size


### PR DESCRIPTION
Hi,
The built-in captcha generator works really well and fits graphically with most pages. Yet there are a few situations where one might need to customize the captcha colors in order to fit specific page colors.

This pull request adds 2 color parameters to the function call : one for background color, one for text color. Also it allows picking random colors out of an array.
