### PR TITLE
Added ability to access MongoCursor in DB\Mongo\Mapper, fixes #452

### DIFF
--- a/lib/db/mongo/mapper.php
+++ b/lib/db/mongo/mapper.php
@@ -24,7 +24,9 @@ class Mapper extends \DB\Cursor {
 		//! Mongo collection
 		$collection,
 		//! Mongo document
-		$document=array();
+		$document=array(),
+	    //! Mongo cursor
+	    $cursor;
 
 	/**
 	*	Return TRUE if field is defined
@@ -135,16 +137,16 @@ class Mapper extends \DB\Cursor {
 				$filter=$filter?:array();
 				$collection=$this->collection;
 			}
-			$cursor=$collection->find($filter,$fields?:array());
+			$this->cursor=$collection->find($filter,$fields?:array());
 			if ($options['order'])
-				$cursor=$cursor->sort($options['order']);
+				$this->cursor=$this->cursor->sort($options['order']);
 			if ($options['limit'])
-				$cursor=$cursor->limit($options['limit']);
+				$this->cursor=$this->cursor->limit($options['limit']);
 			if ($options['offset'])
-				$cursor=$cursor->skip($options['offset']);
+				$this->cursor=$this->cursor->skip($options['offset']);
 			$result=array();
-			while ($cursor->hasnext())
-				$result[]=$cursor->getnext();
+			while ($this->cursor->hasnext())
+				$result[]=$this->cursor->getnext();
 			if ($options['group'])
 				$tmp->drop();
 			if ($fw->get('CACHE') && $ttl)
@@ -274,6 +276,14 @@ class Mapper extends \DB\Cursor {
 		$var=&\Base::instance()->ref($key);
 		foreach ($this->document as $key=>$field)
 			$var[$key]=$field;
+	}
+	
+	/**
+	 * Get the cursor from the last query
+	 * @return MongoCursor|NULL 
+	 */
+	function cursor() {
+        return $this->cursor;
 	}
 
 	/**


### PR DESCRIPTION
Gives you the ability to get the MongoCursor from the last DB\Mongo\Mapper::select() request.  Fixes #452
https://github.com/bcosca/fatfree/issues/452
