### PR TITLE
use $ttl for cookie expiration time

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -210,9 +210,16 @@ final class Base {
 		if (preg_match('/^(GET|POST|COOKIE)\b(.+)/',$key,$expr)) {
 			$this->set('REQUEST'.$expr[2],$val);
 			if ($expr[1]=='COOKIE') {
+				if($ttl) {
+					$expire_default = $this->hive['JAR']['expire'];
+					$this->hive['JAR']['expire'] = time() + $ttl;
+					$ttl = 0;
+				}
 				$parts=$this->cut($key);
 				call_user_func_array('setcookie',
 					array_merge(array($parts[1],$val),$this->hive['JAR']));
+				if(isset($expire_default))
+					$this->hive['JAR']['expire'] = $expire_default;
 			}
 		}
 		else switch ($key) {


### PR DESCRIPTION
I thought about enhancing this sort of usage:

``` php
$f3->set('COOKIE.foo','bar',60); // 1 minute cookie
```

Currently, the $ttl is used to save this key-value pair in cache. I think this isn't very helpful at all.
Instead, it would be cool to bypass the default `JAR.expire` time with this $ttl parameter when setting COOKIE values. So you don't have to change it, if you like to treat a single cookie a bit different. And this would be even more intuitive along the expected behaviour.
