### PR TITLE
Bugfix: BASE misdefined in command line mode

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -1507,7 +1507,9 @@ final class Base {
 		$scheme=isset($_SERVER['HTTPS']) && $_SERVER['HTTPS']=='on' ||
 			isset($headers['X-Forwarded-Proto']) &&
 			$headers['X-Forwarded-Proto']=='https'?'https':'http';
-		$base=preg_replace('/\/[^\/]+$/','',$_SERVER['SCRIPT_NAME']);
+		$base='';
+		if (PHP_SAPI!='cli')
+			$base=preg_replace('/\/[^\/]+$/','',$_SERVER['SCRIPT_NAME']);
 		preg_match('/'.preg_quote($base,'/').'(.*)/',
 			parse_url($_SERVER['REQUEST_URI'],PHP_URL_PATH),$path);
 		call_user_func_array('session_set_cookie_params',


### PR DESCRIPTION
For example, if a script is called like `php index.php /test`, `BASE` contains `"index.php"` instead of being an empty string.
