### PR TITLE
Fix date_default_timezone_get()

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -1586,7 +1586,7 @@ final class Base {
 			'SERIALIZER'=>extension_loaded($ext='igbinary')?$ext:'php',
 			'TEMP'=>'tmp/',
 			'TIME'=>microtime(TRUE),
-			'TZ'=>@date_default_timezone_get('date.timezone')?:'UTC',
+			'TZ'=>@date_default_timezone_get()?:'UTC',
 			'UI'=>'./',
 			'UNLOAD'=>NULL,
 			'UPLOADS'=>'./',


### PR DESCRIPTION
Parameter useless
http://www.php.net/manual/en/function.date-default-timezone-get.php

About the `@` :
if date_default_timezone_get fails, shouldn't it fallback to 'UTC'? 
if it fails, then the line 1605
`date_default_timezone_set($this->hive['TZ']);` 
will set 'TZ' to NULL instead of 'UTC'

maybe 

``` php
'TZ'=>($ddtz=@date_default_timezone_get())?$ddtz:'UTC',
```
