### PR TITLE
Avoid hitting int|bool substrings that lead to wrong pdo_type

### DIFF
--- a/lib/db/sql.php
+++ b/lib/db/sql.php
@@ -273,7 +273,7 @@ class SQL extends \PDO {
 					$rows[$row[$val[1]]]=array(
 						'type'=>$row[$val[2]],
 						'pdo_type'=>
-							preg_match('/int|bool/i',$row[$val[2]],$parts)?
+							preg_match('/^int|^bool/i',$row[$val[2]],$parts)?
 							constant('\PDO::PARAM_'.strtoupper($parts[0])):
 							\PDO::PARAM_STR,
 						'default'=>$row[$val[3]],


### PR DESCRIPTION
Example : "enum('mail','phone','internal')"
Will result in pdo_type => PDO::PARAM_INT
