### PR TITLE
Fix __construct

### DIFF
--- a/lib/image.php
+++ b/lib/image.php
@@ -546,7 +546,7 @@ class Image {
 			$this->file=$file;
 			foreach ($fw->split($path?:$fw->get('UI').';./') as $dir)
 				if (is_file($dir.$file))
-					$this->load($fw->read($dir.$file));
+					return $this->load($fw->read($dir.$file));
 		}
 	}
 


### PR DESCRIPTION
so it changes the behaviour when there are 2+ `$file`s found. We get the 1st one now.

P.S.
When $file not found, how to know it? could we have a public flag, or a `loaded()` primitive?
