### PR TITLE
smtp->send: Allowing ssl when using an external host

### DIFF
--- a/lib/smtp.php
+++ b/lib/smtp.php
@@ -142,9 +142,9 @@ class SMTP extends Magic {
 	*	@param $message string
 	**/
 	function send($message) {
-		if ($this->scheme=='ssl' && !extension_loaded('openssl'))
-			return FALSE;
 		$fw=Base::instance();
+		if ($this->scheme=='ssl' && $this->host==$fw->get('HOST') && !extension_loaded('openssl'))
+			return FALSE;
 		// Connect to the server
 		$socket=&$this->socket;
 		$socket=@fsockopen($this->host,$this->port);


### PR DESCRIPTION
Allowing ssl when OpenSSL is not loaded/available on the PHP server but we don't mind as we are using another host (like smtp.gmail.com not to mention it)

**UPDATE**: 
`stream_socket_enable_crypto` needs it, but it's then related to the TLS scheme. Should we then put `!extension_loaded('openssl')` line 158?

``` php
if (strtolower($this->scheme)=='tls' && extension_loaded('openssl'))`  + `else return FALSE;
```
