### PR TITLE
UTF->emojify() : Free up the hive

### DIFF
--- a/lib/utf.php
+++ b/lib/utf.php
@@ -197,7 +197,7 @@ class UTF extends Prefab {
 	*	@return string
 	*	@param $str string
 	**/
-	function emojify($str) {
+	function emojify($str,$extraset=array()) {
 		$map=array(
 			':('=>'\u2639', // frown
 			':)'=>'\u263a', // smile
@@ -209,7 +209,7 @@ class UTF extends Prefab {
 			':,'=>'\u1f60f', // think
 			':/'=>'\u1f623', // skeptic
 			'8O'=>'\u1f632', // oops
-		)+Base::instance()->get('EMOJI');
+		)+(is_array($extraset)?$extraset:array());
 		return $this->translate(str_replace(array_keys($map),
 			array_values($map),$str));
 	}


### PR DESCRIPTION
Get rid of another 'yet another global system var in the hive' unless there is a global reason to have that extra set into the hive?
