### PR TITLE
strpos: Compliance with standard PHP strpos method

### DIFF
--- a/lib/utf.php
+++ b/lib/utf.php
@@ -48,7 +48,7 @@ class UTF extends Prefab {
 	function strpos($stack,$needle,$ofs=0,$case=FALSE) {
 		preg_match('/^(.*?)'.preg_quote($needle,'/').'/u'.($case?'i':''),
 			$this->substr($stack,$ofs),$match);
-		return isset($match[1])?$this->strlen($match[1]):FALSE;
+		return isset($match[1])?$this->strlen($match[1])+$ofs:FALSE;
 	}
 
 	/**


### PR DESCRIPTION
Returns the position of where the needle exists relative to the beginning of the haystack string **independent of offset** like the standard PHP strpos function. http://php.net/manual/en/function.strpos.php
