### PR TITLE
add unit tests for UTF->substr() (Issue #501)

### DIFF
--- a/app/unicode.php
+++ b/app/unicode.php
@@ -37,6 +37,10 @@ class Unicode extends Controller {
 			'substr (negative offset)'
 		);
 		$test->expect(
+			$utf->substr('El pingüino Wenceslao hizo kilómetros',-10,4)=='kiló',
+			'substr with negative offset and length'
+		);
+		$test->expect(
 			$utf->strpos('Góa ē-tàng chia̍h po-lê','tàng')==6,
 			'strpos'
 		);


### PR DESCRIPTION
substr with negative offset returns all the remaining string whatever length is asked
