### PR TITLE
Map sql tinyint to pdo bool

### DIFF
--- a/lib/db/sql.php
+++ b/lib/db/sql.php
@@ -279,10 +279,10 @@ class SQL extends \PDO {
 						$rows[$row[$val[1]]]=array(
 							'type'=>$row[$val[2]],
 							'pdo_type'=>
-								preg_match('/int\b|int(?=eger)|bool/i',
+								preg_match('/int\b|int(?=eger)|tinyint|bool/i',
 									$row[$val[2]],$parts)?
 								constant('\PDO::PARAM_'.
-									strtoupper($parts[0])):
+									strtoupper($parts[0]=='tinyint'?'bool':$parts[0])):
 								\PDO::PARAM_STR,
 							'default'=>$row[$val[3]],
 							'nullable'=>$row[$val[4]]==$val[5],


### PR DESCRIPTION
I ran into a problem where tinyint in MySQL, which is used for booleans, where not being mapped to PDO::PARAM_BOOL.

For my project I made a minor modification to the sql pdo wrapper to treat tinyint as a special case in the schema function. Thought I'd share it.
