### PR TITLE
fix numeric array keys in template token

### DIFF
--- a/app/template.php
+++ b/app/template.php
@@ -33,6 +33,10 @@ class Template extends Controller {
 			$expr.': '.$eval
 		);
 		$test->expect(
+			$tpl->token($expr='@foo.0')==($eval='$foo[0]'),
+			$expr.': '.$eval
+		);
+		$test->expect(
 			$tpl->token($expr='@foo.@bar')==($eval='$foo.$bar'),
 			$expr.': '.$eval
 		);

--- a/lib/base.php
+++ b/lib/base.php
@@ -188,8 +188,10 @@ class Base extends Prefab {
 				return '$'.preg_replace_callback(
 					'/\.(\w+)|\[((?:[^\[\]]*|(?R))*)\]/',
 					function($expr) use($fw) {
-						return '['.var_export($expr[1]?:
-							$fw->compile($expr[2]),TRUE).']';
+						if (ctype_digit($expr[1]))
+							$expr[1] = (int) $expr[1];
+						return '['.var_export(($expr[1]||is_int($expr[1]))?
+							$expr[1]:$fw->compile($expr[2]),TRUE).']';
 					},
 					$var[1]
 				);


### PR DESCRIPTION
There is an issue when trying to access arrays values by their numeric key, for example:

``` php
$f3->set('foo',array('a','b','c'));
```

``` html
{{ @foo.0 }}
```

Will lead to an **Undefined index 2** error. Here is a related topic in the GG:
https://groups.google.com/forum/#!topic/f3-framework/3CtA4iUcqwk
