### PR TITLE
sqlsrv: allow setting primary keys on insert 

### DIFF
--- a/lib/db/sql/mapper.php
+++ b/lib/db/sql/mapper.php
@@ -334,7 +334,7 @@ class Mapper extends \DB\Cursor {
 				$values.=($ctr?',':'').'?';
 				$args[$ctr+1]=array($field['value'],$field['pdo_type']);
 				$ctr++;
-                $ckeys[]=$key;
+				$ckeys[]=$key;
 			}
 			$field['changed']=FALSE;
 			unset($field);
@@ -343,9 +343,9 @@ class Mapper extends \DB\Cursor {
 			\Base::instance()->call($this->trigger['beforeinsert'],
 				array($this,$pkeys));
 		if ($fields) {
-            $precmd=(preg_match('/mssql|dblib|sqlsrv/',$this->engine)
-                && array_intersect(array_keys($pkeys),$ckeys))?
-                'SET IDENTITY_INSERT '.$this->table.' ON;' : '';
+			$precmd=(preg_match('/mssql|dblib|sqlsrv/',$this->engine)
+				&& array_intersect(array_keys($pkeys),$ckeys))?
+				'SET IDENTITY_INSERT '.$this->table.' ON;' : '';
 			$this->db->exec($precmd.
 				'INSERT INTO '.$this->table.' ('.$fields.') '.
 				'VALUES ('.$values.')',$args


### PR DESCRIPTION
I played a bit with sql server recently. After some tests with the schema builder, i found that sql server does not allow to set values to primary key fields, like
`$mapper->id = 5;` (useful for migration scripts or when using combined / composite pkeys)
Instead it'll shout out:

```
Cannot insert explicit value for identity column in table 'TableName'
when IDENTITY_INSERT is set to OFF.
```

And since it seems that there is no way of turning this on globally, or in an extra db->exec before saving the mapper, i added this to the insert query itself.
