### PR TITLE
Enhancement: Optional Content-Type header on view rendering

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -2088,7 +2088,7 @@ class View extends Prefab {
 				if (isset($_COOKIE[session_name()]))
 					@session_start();
 				$fw->sync('SESSION');
-				if (PHP_SAPI!='cli')
+				if ($mime && PHP_SAPI!='cli')
 					header('Content-Type: '.$mime.'; '.
 						'charset='.$fw->get('ENCODING'));
 				$data=$this->sandbox($hive);
@@ -2197,7 +2197,7 @@ class Preview extends View {
 				if (isset($_COOKIE[session_name()]))
 					@session_start();
 				$fw->sync('SESSION');
-				if (PHP_SAPI!='cli')
+				if ($mime && PHP_SAPI!='cli')
 					header('Content-Type: '.($this->mime=$mime).'; '.
 						'charset='.$fw->get('ENCODING'));
 				$data=$this->sandbox($hive);


### PR DESCRIPTION
Hi,
there are a few cases where one needs to render a template without sending HTTP headers (for example when rendering an e-mail template). Setting the `$mime` argument to NULL should be enough to prevent headers from being sent.
