### PR TITLE
[MongoMapper] Fixed bug "Undefined variable: pkey"

### DIFF
--- a/lib/db/mongo/mapper.php
+++ b/lib/db/mongo/mapper.php
@@ -229,7 +229,7 @@ class Mapper extends \DB\Cursor {
 		if (isset($this->document['_id']))
 			return $this->update();
 		if (isset($this->trigger['beforeinsert']))
-			\Base::instance()->call($this->trigger['beforeinsert'], array());
+			\Base::instance()->call($this->trigger['beforeinsert'], array($this));
 		$this->collection->insert($this->document);
 		$pkey=array('_id'=>$this->document['_id']);
 		if (isset($this->trigger['afterinsert']))


### PR DESCRIPTION
$pkey was defined after using, also line 229 assume that we never have mongo pkey '_id' on line 232
