### PR TITLE
Autoloader casing when only first letter is of different case in filename

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -1550,16 +1550,14 @@ class Base extends Prefab {
 	**/
 	protected function autoload($class) {
 		$class=$this->fixslashes(ltrim($class,'\\'));
+		$callback=isset($this->hive['AUTOLOAD_CALLBACK'])?
+			$this->hive['AUTOLOAD_CALLBACK']:NULL;
 		foreach ($this->split($this->hive['PLUGINS'].';'.
 			$this->hive['AUTOLOAD']) as $auto)
 			if (is_file($file=$auto.$class.'.php') ||
 				is_file($file=$auto.strtolower($class).'.php') ||
 				is_file($file=strtolower($auto.$class).'.php') ||
-				is_file($file=preg_replace_callback('/\/([A-Z])/',
-					function($match){
-						return strtolower($match[0]);
-					},
-					$auto.$class).'.php'))
+				$callback && is_file($file=$this->call($callback,$auto.$class)))
 				return require($file);
 	}
 


### PR DESCRIPTION
The documentation for the F3 Autoloader states:

> Important: The class name and file name must be identical so the framework can autoload your class. If your class is named BarBaz, your file must be named barbaz.php (case does not matter).

There's a use case here that is not handled, when a namespace directory has only the first letter of filename in lowercase (e.g., ..`/controllers` for `Controllers` namespace) - or the class filename (`sampleController.php` for `SampleController`). For the example in the documentation, the filename could be named `barBaz.php`.

This pull request handles the use case described above.
