### PR TITLE
SQL Mapper->find: GROUP BY SQL compliant statement

### DIFF
--- a/lib/db/sql/mapper.php
+++ b/lib/db/sql/mapper.php
@@ -251,8 +251,8 @@ class Mapper extends \DB\Cursor {
 		$adhoc='';
 		foreach ($this->adhoc as $key=>$field)
 			$adhoc.=','.$field['expr'].' AS '.$this->db->quotekey($key);
-		return $this->select(implode(',',
-			array_map(array($this->db,'quotekey'),array_keys($this->fields))).
+		return $this->select(($options['group']?:implode(',',
+			array_map(array($this->db,'quotekey'),array_keys($this->fields)))).
 			$adhoc,$filter,$options,$ttl);
 	}
 


### PR DESCRIPTION
Hi,
here's a small patch for the `find()` method to return a valid SQL statement when grouping rows.
The existing code is working with MySQL but fails on stricter engines.
