### PR TITLE
[Jig] reduce handlers and group feature

### DIFF
--- a/lib/db/jig/mapper.php
+++ b/lib/db/jig/mapper.php
@@ -26,7 +26,10 @@ class Mapper extends \DB\Cursor {
 		//! Document identifier
 		$id,
 		//! Document contents
-		$document=array();
+		$document=array(),
+		//! field reduce handlers
+		$rFields;
+
 
 	/**
 	*	Return database type
@@ -154,6 +157,7 @@ class Mapper extends \DB\Cursor {
 			$options=array();
 		$options+=array(
 			'order'=>NULL,
+			'group'=>NULL,
 			'limit'=>0,
 			'offset'=>0
 		);
@@ -227,30 +231,35 @@ class Mapper extends \DB\Cursor {
 					}
 				);
 			}
-			if (isset($options['order'])) {
-				$cols=$fw->split($options['order']);
-				uasort(
-					$data,
-					function($val1,$val2) use($cols) {
-						foreach ($cols as $col) {
-							$parts=explode(' ',$col,2);
-							$order=empty($parts[1])?
-								SORT_ASC:
-								constant($parts[1]);
-							$col=$parts[0];
-							if (!array_key_exists($col,$val1))
-								$val1[$col]=NULL;
-							if (!array_key_exists($col,$val2))
-								$val2[$col]=NULL;
-							list($v1,$v2)=array($val1[$col],$val2[$col]);
-							if ($out=strnatcmp($v1,$v2)*
-								(($order==SORT_ASC)*2-1))
-								return $out;
-						}
-						return 0;
+			if (isset($options['group'])) {
+				$cols=array_reverse($fw->split($options['group']));
+				// sort into groups
+				$data=$this->sort($data,$options['group']);
+				foreach($data as $index=>&$row) {
+					if(!isset($prev)) {
+						$prev=$row;
+						$pi=$index;
 					}
-				);
+					$drop=false;
+					foreach ($cols as $col)
+						if (array_key_exists($col,$row) &&
+							array_key_exists($col,$prev) &&
+							$row[$col] == $prev[$col] && $pi != $index) {
+							$drop=true;
+							if (isset($this->rFields[$col]))
+								$prev=call_user_func($this->rFields[$col],$prev,$row);
+						} elseif (isset($this->rFields[$col]))
+							$row=call_user_func($this->rFields[$col],$row,null);
+					if($drop)
+						unset($data[$index]);
+					else {
+						$prev=&$row;
+						$pi=$index;
+					}
+				}
 			}
+			if (isset($options['order']))
+				$data=$this->sort($data,$options['order']);
 			$data=array_slice($data,
 				$options['offset'],$options['limit']?:NULL,TRUE);
 			if ($fw->get('CACHE') && $ttl)
@@ -274,6 +283,47 @@ class Mapper extends \DB\Cursor {
 				($filter?preg_replace($keys,$vals,$filter[0],1):''));
 		}
 		return $out;
+	}
+
+	/**
+	*	Add reduce handler for grouped fields
+	*	@param $key
+	*	@param $callback
+	*/
+	function reduce($key,$callback){
+		$this->rFields[$key]=$callback;
+	}
+
+	/**
+	*	Sort a data collection
+	*	@param $data
+	*	@param $cond
+	*	@return mixed
+	*/
+	protected function sort($data,$cond) {
+		$cols=\Base::instance()->split($cond);
+		uasort(
+			$data,
+			function($val1,$val2) use($cols) {
+				foreach ($cols as $col) {
+					$parts=explode(' ',$col,2);
+					$order=empty($parts[1])?
+						SORT_ASC:
+						constant($parts[1]);
+					$col=$parts[0];
+					if (!array_key_exists($col,$val1))
+						$val1[$col]=NULL;
+					if (!array_key_exists($col,$val2))
+						$val2[$col]=NULL;
+					list($v1,$v2)=array($val1[$col],$val2[$col]);
+					if ($out=strnatcmp($v1,$v2)*
+						(($order==SORT_ASC)*2-1))
+						return $out;
+				}
+				return 0;
+			}
+		);
+		return $data;
 	}
 
 	/**


### PR DESCRIPTION
I've played around with Jig again and added a little group feature that was still missing here.

It goes like this:

``` php
$books = new \DB\Jig\Mapper($f3->get('DB'),'books');
$res = $books->find(null,array('group'=>'year'));
```

Now it first filters the database (`null` in this example), then sort the result array for the grouped fields and drops all rows that have the same value as its ancestors. You can define a handler which is called on every matching row. You can use that to create own new fields to aggredate fields or add computed values.

Like this:

``` php
$books->reduce('year',function($dest,$cur){
    if (!isset($dest['count']))
        $dest['count'] = 1;
    else
        $dest['count']++;
    return $dest;
});
$res = $books->find(null,array('group'=>'year'));
```

This will add a new `count` fields to your rows, that tells you how many books was found by each grouped year. We can also add some aggregation to our handlers:

``` php
$books->reduce('year',function($dest,$cur){
    // $dest is the first/final row that will remain in your result
    // $cur is null or a descendant row that will be dropped due to the group action
    if (!isset($dest['count']))
        $dest['count'] = 1;
    else
        $dest['count']++;
    // sum how many books we have in stock per released year
    if (!isset($dest['sum_stock']))
        $dest['sum_stock'] = 0;
    else
        $dest['sum_stock']+=$cur['stock'];
    return $dest;
});
$res = $books->find(null,array('group'=>'year'));
```

You can also group on multiple fields and even sort the whole set afterwards using your own custom fields:

``` php
$books->find(null,array('group'=>'year,author', 'order'=>'year SORT_ASC, sum_stock SORT_DESC'));
```

This was just a quick shot so far. Maybe another one can test this again if there is some spare time.
