### PR TITLE
image overlay with transparency and alignment control

### DIFF
--- a/app/image.php
+++ b/app/image.php
@@ -176,6 +176,16 @@ class Image extends Controller {
 				'<img src="'.$src.'" '.
 					'title="'.$img->width().'x'.$img->height().'" />'
 			);
+			$ovr=new \Image('images/watermark.png');
+			$ovr->resize(100,38)->rotate(45);
+			$test->expect(
+				$src=$f3->base64($img->restore()->
+					overlay($ovr,array(65,25),50)->
+					dump(),'image/png'),
+				'Overlay, 50% transparency, manually aligned<br />'.
+				'<img src="'.$src.'" '.
+					'title="'.$img->width().'x'.$img->height().'" />'
+			);
 			$test->expect(
 				$src=$f3->base64($img->restore()->dump('gif'),'image/gif'),
 				'Convert to GIF format<br />'.

--- a/lib/image.php
+++ b/lib/image.php
@@ -270,11 +270,16 @@ class Image {
 	*	Apply an image overlay
 	*	@return object
 	*	@param $img object
-	*	@param $align int
+	*	@param $align int|array
+	*	@param $alpha int
 	**/
-	function overlay(Image $img,$align=NULL) {
+	function overlay(Image $img,$align=NULL,$alpha=100) {
 		if (is_null($align))
 			$align=self::POS_Right|self::POS_Bottom;
+		if (is_array($align)) {
+			list($posx,$posy)=$align;
+			$align = 0;
+		}
 		$ovr=imagecreatefromstring($img->dump());
 		imagesavealpha($ovr,TRUE);
 		$imgw=$this->width();
@@ -297,7 +302,14 @@ class Image {
 			$posx=0;
 		if (empty($posy))
 			$posy=0;
-		imagecopy($this->data,$ovr,$posx,$posy,0,0,$ovrw,$ovrh);
+		if ($alpha==100)
+			imagecopy($this->data,$ovr,$posx,$posy,0,0,$ovrw,$ovrh);
+		else {
+			$cut=imagecreatetruecolor($ovrw,$ovrh);
+			imagecopy($cut,$this->data,0,0,$posx,$posy,$ovrw,$ovrh);
+			imagecopy($cut,$ovr,0,0,0,0,$ovrw,$ovrh);
+			imagecopymerge($this->data,$cut,$posx,$posy,0,0,$ovrw,$ovrh,$alpha);
+		}
 		return $this->save();
 	}
 


### PR DESCRIPTION
i needed this for an image builder, so i added control about the alpha channel on overlays, and the possibility to align the overlay pixel-perfect with an `array($x,$y)` as $align parameter.

working unit test at: http://f3.ikkez.de/image
