### PR TITLE
Fix missing newlines after template expansion

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -2116,7 +2116,7 @@ class Preview extends View {
 	protected function build($node) {
 		$self=$this;
 		return preg_replace_callback(
-			'/\{\{(.+?)\}\}/s',
+			'/\{\{(.+?)\}\}(\n)?/s',
 			function($expr) use($self) {
 				$str=trim($self->token($expr[1]));
 				if (preg_match('/^(.+?)\h*\|(\h*\w+(?:\h*[,;]\h*\w+)*)/',
@@ -2126,7 +2126,7 @@ class Preview extends View {
 						$str=(($func=='format')?'\Base::instance()':'$this').
 							'->'.$func.'('.$str.')';
 				}
-				return '<?php echo '.$str.'; ?>';
+				return '<?php echo '.$str.'; ?>'.(isset($expr[2]) ? "\n\n" : '');
 			},
 			preg_replace_callback(
 				'/\{~(.+?)~\}/s',


### PR DESCRIPTION
Before this commit the following code:

```
$template = "{{ @foo }}\nbar\n";
var_dump(Preview::instance()->resolve($template, array('foo' => 'bar')));
```

Would output:

```
string(7) "barbar\n"
```

This is because the template expander will replace `{{ … }}` with `<?php … ?>` and when such tags are followed by a newline, the PHP preprocessor omits it.

Since the template engine is mentioned as useful for generating emails, the newline stripping behavior is undesired and should not be inherited from PHP.
