### PR TITLE
[template] fix node attribute with empty & zero values

### DIFF
--- a/app/template.php
+++ b/app/template.php
@@ -329,6 +329,16 @@ class Template extends Controller {
 				array('@attrib'=>array('bar'=>'test15','baz'=>'abc'),'multi-line start tag')),
 			'Custom tag spanning multiple lines'
 		);
+		$test->expect(
+			isset($lines[15]) && $lines[15]==$f3->stringify(
+				array('@attrib'=>array('value'=>'0'))),
+			'Node attribute with 0 value'
+		);
+		$test->expect(
+			isset($lines[16]) && $lines[16]==$f3->stringify(
+				array('@attrib'=>array('bar'=>NULL,'baz'=>'1'))),
+			'Node attribute with empty value'
+		);
 		$f3->set('foo','bar');
 		$f3->set('file','templates/test14.htm');
 		$test->expect(

--- a/lib/template.php
+++ b/lib/template.php
@@ -297,7 +297,7 @@ class Template extends Preview {
 						// Process attributes
 						preg_match_all(
 							'/(?:\b([\w-]+)\h*'.
-							'(?:=\h*(?:"(.+?)"|\'(.+?)\'))?|'.
+							'(?:=\h*(?:"(.*?)"|\'(.*?)\'))?|'.
 							'(\{\{.+?\}\}))/s',
 							$match[3],$attr,PREG_SET_ORDER);
 						foreach ($attr as $kv)
@@ -305,8 +305,8 @@ class Template extends Preview {
 								$node['@attrib'][]=$kv[4];
 							else
 								$node['@attrib'][$kv[1]]=
-									(empty($kv[2])?
-										(empty($kv[3])?NULL:$kv[3]):$kv[2]);
+									((isset($kv[2]) && $kv[2]!=='')?$kv[2]:
+										((isset($kv[3]) && $kv[3]!=='')?$kv[3]:NULL));
 					}
 					if ($match[4])
 						// Empty tag

--- a/ui/templates/test10.htm
+++ b/ui/templates/test10.htm
@@ -14,3 +14,5 @@
 <foo bar="test14">this {{ @token }} should NOT get resolved</foo>
 <foo bar="test15"
         baz="abc">multi-line start tag</foo>
+<foo value="0" />
+<foo bar="" baz="1" />


### PR DESCRIPTION
Just noticed a little misbehaviour for node attributes that contains a `0` value or nothing:

``` html
<input value="0" foo="" baz="1" />
```

parsed:

```
array(1) {
  ["@attrib"]=>
  array(3) {
    ["value"] => NULL
    ["foo"] => string(6) "" baz="
    [1]=> NULL
  }
}
```

expected (and fixed with this commit):

```
array(1) {
  ["@attrib"]=>
  array(3) {
    ["value"] => string(1) "0"
    ["foo"] => NULL
    ["baz"] => string(1) "1"
  }
}
```
