### PR TITLE
Web->request: allow file upload with curl

### DIFF
--- a/lib/web.php
+++ b/lib/web.php
@@ -474,7 +474,7 @@ class Web extends Prefab {
 				'Connection: close'
 			)
 		);
-		if (isset($options['content'])) {
+		if (isset($options['content']) && is_string($options['content'])) {
 			if ($options['method']=='POST')
 				$this->subst($options['header'],
 					'Content-Type: application/x-www-form-urlencoded');


### PR DESCRIPTION
Hi,

In a project there was a need to send a file from the webserver to another webserver. I thought I would try with `$web->request`. It turned out that it could easily be done, providing the engine is set to `curl` and the file name is declared as a `content` prefixed by a `@` sign (cf. option _CURLOPT_POSTFIELDS_ in [cURL doc](http://php.net/manual/en/function.curl-setopt.php)).

The only thing is that in that case, `content` has to be passed as an array, and the headers `Content-Type` and  `Content-Length` don't have to be automatically computed by F3 since cURL will do it. Hence this pull request.

Example:

```
$web->engine('curl');
$content=array(
  'field1'=>'value1',
  'field2'=>'value2',
  'file1'=>'@/foo/bar/myfile.ext',
);
$web->request($url,array(
  'method'=>'POST',
  'content'=>$content
));
```
