### PR TITLE
Ensure that	$str == $f3->decode($f3->encode($str))

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -635,7 +635,7 @@ class Base extends Prefab {
 	**/
 	function encode($str) {
 		return @htmlentities($str,$this->hive['BITMASK'],
-			$this->hive['ENCODING'],FALSE)?:$this->scrub($str);
+			$this->hive['ENCODING'])?:$this->scrub($str);
 	}
 
 	/**


### PR DESCRIPTION
Base::encode would not encode existing entities which is a problem since hive variables are always entity encoded (via Base::encode) and then decoded again if the user disables escaping either by setting the ESCAPE hive variable to true or using the `raw` template function.

So if we have a hive variable with HTML we want to insert verbatim, then this was previously not possible, if that HTML code contained HTML entities.
