### PR TITLE
dangerous caching of cookie values

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -291,7 +291,7 @@ class Base extends Prefab {
 				if ($ttl)
 					$jar['expire']=time()+$ttl;
 				call_user_func_array('setcookie',array($parts[1],$val)+$jar);
-				return $this->ref($key);
+				return $val;
 			}
 		}
 		else switch ($key) {


### PR DESCRIPTION
Setting a cookie with an explicit TTL makes the cookie value get cached.
That behaviour can cause big security issues. Thx to Peter Matthaei for reporting at 
https://groups.google.com/forum/#!topic/f3-framework/B4xXnydzviI
