### PR TITLE
Mock : improvement on treatment of superglobals and request body

### DIFF
--- a/app/router.php
+++ b/app/router.php
@@ -137,7 +137,7 @@ class Router extends Controller {
 			$f3->get('id')=='bread',
 			'Different parameter in route'
 		);
-		$f3->route('GET @grub:/food/@id/@quantity',
+		$f3->route('GET|POST|PUT @grub:/food/@id/@quantity',
 			function($f3,$args) {
 				$f3->set('id',$args['id']);
 				$f3->set('quantity',$args['quantity']);
@@ -171,6 +171,21 @@ class Router extends Controller {
 		$test->expect(
 			$f3->get('id')=='chicken' && $f3->get('quantity')==999,
 			'Route parameters captured along with query'
+		);
+		$f3->mock('POST /food/sushki/134?a=1',array('b'=>2));
+		$test->expect(
+			$_GET==array('a'=>1) && $_POST==array('b'=>2) && $_REQUEST==array('a'=>1,'b'=>2) && $f3->get('BODY')=='b=2',
+			'Request body and superglobals $_GET, $_POST, $_REQUEST correctly set on mocked POST'
+		);
+		$f3->mock('PUT /food/sushki/134?a=1',array('b'=>2));
+		$test->expect(
+			$_GET==array('a'=>1) && $_POST==array() && $_REQUEST==array('a'=>1) && $f3->get('BODY')=='b=2',
+			'Request body and superglobals $_GET, $_POST, $_REQUEST correctly set on mocked PUT'
+		);
+		$f3->mock('POST /food/sushki/134?a=1',array('b'=>2),NULL,'c=3');
+		$test->expect(
+			$_GET==array('a'=>1) && $_POST==array('b'=>2) && $_REQUEST==array('a'=>1,'b'=>2) && $f3->get('BODY')=='c=3',
+			'Mocked request body precedence over arguments'
 		);
 		$f3->mock('GET @grub(@id=%C3%B6%C3%A4%C3%BC,@quantity=123)');
 		$test->expect(


### PR DESCRIPTION
This pull request intends to improve the processing of the following variables : $_GET, $_POST, $_REQUEST and BODY when using `$f3->mock($pattern,$args,$headers,$body)`. It tries to follow the same behaviour as PHP:
- **$_GET**: corresponds to the query string contained in `$pattern`. On a `GET` request, it is merged with `$args`.
- **$_POST**: equals `$args` on a `POST` request _only_.
- **$_REQUEST**: equals to `array_merge($_GET,$_POST)` (this is what PHP does _by default_).
- **BODY**: equals `$body` if it's set, otherwise is built from `$args`. Empty on a `GET` request.
