### PR TITLE
New ONREROUTE variable

### DIFF
--- a/app/router.php
+++ b/app/router.php
@@ -22,6 +22,16 @@ class Router extends Controller {
 		);
 		if (is_file($file))
 			@unlink($file);
+		$f3->set('ONREROUTE',function($url,$permanent){
+			$f3=\Base::instance();
+			$f3->set('reroute',$url);
+		});
+		$f3->reroute('/foo?bar=baz');
+		$test->expect(
+			$f3->get('reroute')=='/foo?bar=baz',
+			'Custom rerouting'
+		);
+		$f3->set('ONREROUTE',NULL);
 		$f3->clear('ROUTES');
 		$f3->route('GET|POST @hello:/',
 			function($f3) {

--- a/lib/base.php
+++ b/lib/base.php
@@ -1130,6 +1130,8 @@ class Base extends Prefab {
 	*	@param $permanent bool
 	**/
 	function reroute($url,$permanent=FALSE) {
+		if (($handler=$this->hive['ONREROUTE']) && $this->call($handler,array($url,$permanent))!==FALSE)
+			return;
 		if (PHP_SAPI!='cli') {
 			if (preg_match('/^(?:@(\w+)(?:(\(.+?)\))*|https?:\/\/)/',
 				$url,$parts)) {
@@ -1711,6 +1713,7 @@ class Base extends Prefab {
 			'LOCALES'=>'./',
 			'LOGS'=>'./',
 			'ONERROR'=>NULL,
+			'ONREROUTE'=>NULL,
 			'PACKAGE'=>self::PACKAGE,
 			'PARAMS'=>array(),
 			'PATH'=>$path,


### PR DESCRIPTION
This is a suggestion to answer issue #655. It is loose enough to fit other needs as well.

It's supposed to work like `ONERROR`, which means that the normal behaviour is not executed unless the return value is `FALSE`.

Examples of use with `$f3->mock()`:

In a test suite, in order to mock internal reroutes and ignore external ones:

``` php
$f3->set('ONREROUTE',function($url,$permanent)use($f3){
  if (!preg_match('/^http/',$url)
    $f3->mock('GET '.$url);
});
$f3->mock(...);
```

In a test suite, in order to simulate the `die` effect of `$f3->reroute`:

``` php
$f3->set('ONREROUTE',function($url,$permanent){
  throw new StopRouteNow();//class StopRouteNow extends Exception {}
});
try {
  $f3->mock(...);
} catch(StopRouteNow $e) {
  //Route has been stopped;
} catch(Exception $e) {
  //Real error here
}
```
