### PR TITLE
add afterrender hook to View class

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -2106,7 +2106,8 @@ class View extends Prefab {
 						'charset='.$fw->get('ENCODING'));
 				$data=$this->sandbox($hive);
 				if(isset($this->trigger['afterrender']))
-					$data=$fw->call($this->trigger['afterrender'],$data);
+					foreach($this->trigger['afterrender'] as $func)
+						$data=$fw->call($func,$data);
 				if ($ttl)
 					$cache->set($hash,$data);
 				return $data;
@@ -2119,7 +2120,7 @@ class View extends Prefab {
 	*	@param $func callback
 	*/
 	function afterrender($func) {
-		$this->trigger['afterrender']=$func;
+		$this->trigger['afterrender'][]=$func;
 	}
 
 }
@@ -2226,7 +2227,8 @@ class Preview extends View {
 						'charset='.$fw->get('ENCODING'));
 				$data=$this->sandbox($hive);
 				if(isset($this->trigger['afterrender']))
-					$data=$fw->call($this->trigger['afterrender'],$data);
+					foreach ($this->trigger['afterrender'] as $func)
+						$data = $fw->call($func, $data);
 				if ($ttl)
 					$cache->set($hash,$data);
 				return $data;


### PR DESCRIPTION
Would be nice to have an `afterrender` hook for the templating. This way we could add own functions to parse the generated templates and modify it slightly before it goes into the `/tmp` cache as pre-compiled final template.

A use case for that could be something like my [draft for an css/js asset manager](https://gist.github.com/ikkez/ef2cfaa3009c439ea484) (being able to add css/js files from the inside of a widget template). It wouldn't be possible without such an event/hook, because there is currently no other way to modify the content of a parent template from the inside of a sub-template. With that after-renderer we can finalize some modifications of the template we might have started in the pre-compile process (adding additional marker or php code).

so far. hope you like it.
