### PR TITLE
Bug fix: Prevent multiple encoding in nested views/templates

### DIFF
--- a/app/template.php
+++ b/app/template.php
@@ -142,6 +142,11 @@ class Template extends Controller {
 			$tpl->render('templates/test2.htm')=='bar',
 			'<include>'
 		);
+		$f3->set('foo','barré');
+		$test->expect(
+			$tpl->render('templates/test2b.htm')=='barr&eacute;barr&eacute;',
+			'double <include> doesn\'t double encode'
+		);
 		$f3->clear('cond');
 		$f3->set('foo','baz');
 		$test->expect(

--- a/lib/base.php
+++ b/lib/base.php
@@ -2042,7 +2042,9 @@ class View extends Prefab {
 		//! Template file
 		$view,
 		//! post-rendering handler
-		$trigger;
+		$trigger,
+		//! Nesting level
+		$level=0;
 
 	/**
 	*	Encode characters to equivalent HTML entities
@@ -2078,11 +2080,11 @@ class View extends Prefab {
 	*	@param $hive array
 	**/
 	protected function sandbox(array $hive=NULL) {
+		$this->level++;
 		$fw=Base::instance();
 		if (!$hive)
 			$hive=$fw->hive();
-		if (!$fw->exists('RENDERING',$rendering)) {
-			$fw->set('RENDERING', true);
+		if ($this->level<2) {
 			if ($fw->get('ESCAPE'))
 				$hive=$this->esc($hive);
 			if (isset($hive['ALIASES']))
@@ -2093,7 +2095,7 @@ class View extends Prefab {
 		unset($hive);
 		ob_start();
 		require($this->view);
-		Base::instance()->clear('RENDERING');
+		$this->level--;
 		return ob_get_clean();
 	}
 

--- a/ui/templates/test2b.htm
+++ b/ui/templates/test2b.htm
@@ -1,0 +1,1 @@
+<include if="{{ @cond }}" href="{{ @file }}" /><include if="{{ @cond }}" href="{{ @file }}" />


### PR DESCRIPTION
Hi,
the `RENDERING` flag introduced in #656 didn't work with multiple nested levels. For example, in such a configuration:

```
//main.html
<include href="sub1.html"/>
<include href="sub2.html"/>
```

the `RENDERING` flag would be erased after rendering sub1.html and therefore all variables would be double encoded in sub2.html

This pull request intends to fix that.
