### PR TITLE
fix overwrite of ENCODING var

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -300,7 +300,7 @@ class Base extends Prefab {
 				$val=Cache::instance()->load($val,TRUE);
 				break;
 			case 'ENCODING':
-				$val=ini_set('default_charset',$val);
+				ini_set('default_charset',$val);
 				if (extension_loaded('mbstring'))
 					mb_internal_encoding($val);
 				break;


### PR DESCRIPTION
`ini_set` returns the old value from php config. That caused the hive var `ENCODING` to be left unchanged after setting something like `ISO-8859-1` to send and render SMTP mails correctly. 
