### PR TITLE
Update mapper.php

### DIFF
--- a/lib/db/sql/mapper.php
+++ b/lib/db/sql/mapper.php
@@ -175,8 +175,7 @@ class Mapper extends \DB\Cursor {
 			'group'=>NULL,
 			'order'=>NULL,
 			'limit'=>0,
-			'offset'=>0,
-			'top'=>0
+			'offset'=>0
 		);
 		
 		if(in_array($this->engine, array('mssql','sqlsrv','odbc')))


### PR DESCRIPTION
Applied fix for SELECT TOP X records when using MS SQL

Usage: array( 'order'=>'DATE_ADDED DESC', 'top'=>10 )

As reported on issue https://github.com/bcosca/fatfree/issues/670
