### PR TITLE
Invalid Class error when using "map routing" with first letter uppercase filename or directory name

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -1566,11 +1566,16 @@ class Base extends Prefab {
 	**/
 	protected function autoload($class) {
 		$class=$this->fixslashes(ltrim($class,'\\'));
+		$class_ar = explode('/',$class);
+		array_walk($class_ar, create_function('&$cls', '$cls = ucwords(strtolower($cls));'));
+		$uc_class = implode('/',$class_ar);
+
 		foreach ($this->split($this->hive['PLUGINS'].';'.
 			$this->hive['AUTOLOAD']) as $auto)
 			if (is_file($file=$auto.$class.'.php') ||
 				is_file($file=$auto.strtolower($class).'.php') ||
-				is_file($file=strtolower($auto.$class).'.php'))
+				is_file($file=strtolower($auto.$class).'.php') ||
+				is_file($file=$auto.$uc_class.'.php'))
 				return require($file);
 	}
 


### PR DESCRIPTION
`"Invalid Class"` error does occur when using "map routing" with first letter uppercase filename or directory name like
`App\Controllers\` and `App\Controllers\Authenticator.php`

The `autoloader` will look for `app/controllers/authenticator.php` instead of `App/controllers/Authenticator.php`
These few lines of code will create another string of uppercase class name and path, then included it in the file existence checking.

I had this problem while working on a big project which works fine on my development PC and doesn't work on my live Web Server.

This is the workaround that fixed the problem.
