### PR TITLE
Provide a single level trace when there is an error

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -1626,7 +1626,10 @@ class Base extends Prefab implements ArrayAccess {
 			$error && in_array($error['type'],
 			array(E_ERROR,E_PARSE,E_CORE_ERROR,E_COMPILE_ERROR)))
 			// Fatal error detected
-			$this->error(500,sprintf(self::E_Fatal,$error['message']));
+			$this->error(500,sprintf(self::E_Fatal,$error['message']),[[
+				'file' => $error['file'],
+				'line' => $error['line']
+			]]);
 	}
 
 	/**
@@ -1736,9 +1739,12 @@ class Base extends Prefab implements ArrayAccess {
 			}
 		);
 		set_error_handler(
-			function($code,$text) use($fw) {
+			function($code,$text,$file,$line) use($fw) {
 				if (error_reporting())
-					$fw->error(500,$text);
+					$fw->error(500,$text,[[
+						'file' => $file,
+						'line' => $line
+					]]);
 			}
 		);
 		if (!isset($_SERVER['SERVER_NAME']))

--- a/lib/base.php
+++ b/lib/base.php
@@ -1626,10 +1626,10 @@ class Base extends Prefab implements ArrayAccess {
 			$error && in_array($error['type'],
 			array(E_ERROR,E_PARSE,E_CORE_ERROR,E_COMPILE_ERROR)))
 			// Fatal error detected
-			$this->error(500,sprintf(self::E_Fatal,$error['message']),[[
+			$this->error(500,sprintf(self::E_Fatal,$error['message']),array(array(
 				'file' => $error['file'],
 				'line' => $error['line']
-			]]);
+			)));
 	}
 
 	/**
@@ -1741,10 +1741,10 @@ class Base extends Prefab implements ArrayAccess {
 		set_error_handler(
 			function($code,$text,$file,$line) use($fw) {
 				if (error_reporting())
-					$fw->error(500,$text,[[
+					$fw->error(500,$text,array(array(
 						'file' => $file,
 						'line' => $line
-					]]);
+					)));
 			}
 		);
 		if (!isset($_SERVER['SERVER_NAME']))


### PR DESCRIPTION
Currently there are no details of where the error is, when one is caught. This adds an entry into the backtrace to show where it is.