### PR TITLE
fix user error in call function

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -1390,8 +1390,7 @@ class Base extends Prefab implements ArrayAccess {
 			preg_match('/(.+)\h*(->|::)\h*(.+)/s',$func,$parts)) {
 			// Convert string to executable PHP callback
 			if (!class_exists($parts[1]))
-				user_error(sprintf(self::E_Class,
-					is_string($func)?$parts[1]:$this->stringify()));
+				user_error(sprintf(self::E_Class,$parts[1]));
 			if ($parts[2]=='->')
 				$parts[1]=is_subclass_of($parts[1],'Prefab')?
 					call_user_func($parts[1].'::instance'):


### PR DESCRIPTION
just noticed that `$this->stringify()` had a missing argument.
But then i saw that the whole condition is redundant, because `is_string($func)` was already checked in the parent if condition at https://github.com/bcosca/fatfree/blob/dev/lib/base.php#L1389
So i think it's fine to clean it up here.
