### PR TITLE
Adds four methods needed for Cursor to implement Iterator.

### DIFF
--- a/lib/db/cursor.php
+++ b/lib/db/cursor.php
@@ -16,7 +16,7 @@
 namespace DB;
 
 //! Simple cursor implementation
-abstract class Cursor extends \Magic {
+abstract class Cursor extends \Magic implements \Iterator, \Countable {
 
 	//@{ Error messages
 	const
@@ -199,6 +199,35 @@ abstract class Cursor extends \Magic {
 	**/
 	function prev() {
 		return $this->skip(-1);
+	}
+
+	/**
+	 * Get the current record.
+	 * Used in iteration.
+	 */
+	function current() {
+		return $this;
+	}
+
+	/**
+	 * Get a key for teh current record.
+	 */
+	function key() {
+		return $this->ptr;
+	}
+
+	/**
+	 * Rewind iteration.
+	 */
+	function rewind() {
+		return $this->first();
+	}
+
+	/**
+	 * Return whether current iterator position is valid.
+	 */
+	function valid() {
+		return !$this->dry();
 	}
 
 	/**


### PR DESCRIPTION
Adds four methods needed for Cursor to implement Iterator for convenience in line with SPL approach to collections.

All trivial wrappers on existing methods. Cursor was already setup to support basic Iterator requirements, although it has particular behavior for incrementing current position out of bounds, which is all maintained.

Aside: I also think it would be nicer if Pagination was provided through an Iterator too. I might try to do that later and push rel another ticket.

See http://php.net/manual/en/class.iterator.php.
