### PR TITLE
Add record of routed route to hive. Refs #692.

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -1290,7 +1290,7 @@ class Base extends Prefab implements ArrayAccess {
 					preg_match('/.+\/$/',$parts['path']))
 					$this->reroute(substr($parts['path'],0,-1).
 						(isset($parts['query'])?('?'.$parts['query']):''));
-				list($handler,$ttl,$kbps)=$route[$this->hive['VERB']];
+				list($handler,$ttl,$kbps,$uri,$type,$verb,$alias)=$route[$this->hive['VERB']];
 				if (is_bool(strpos($url,'/*')))
 					foreach (array_keys($args) as $key)
 						if (is_numeric($key) && $key)
@@ -1311,6 +1311,7 @@ class Base extends Prefab implements ArrayAccess {
 				$this->hive['PARAMS']=$args=array_map('urldecode',$args);
 				// Save matching route
 				$this->hive['PATTERN']=$url;
+				$this->hive['ALIAS']=$alias;
 				$this->hive['ROUTE']=$route[$this->hive['VERB']];
 				// Process request
 				$result=NULL;


### PR DESCRIPTION
Now, when a route is selected in Base::run(), a record of that route is kept in the hive var 'ROUTE'. Currently routes are stored internally as a hierarchical hash for efficient look up. I also changed the code to collapse the values of the hash keys (uri,type,verb) into the route record. It could be argued its slightly space inefficient, but that is my preferred way of doing it.

Also note the route records (which are also available via 'ROUTES') are currently indexed arrays not assoc arrays which makes them a bit awkward. Solution would be to define the offsets as consts in \BASE or change the record to a hash.
