### PR TITLE
Update base.php

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -693,7 +693,7 @@ class Base extends Prefab implements ArrayAccess {
 					$ref=new ReflectionClass($arg);
 					if ($ref->iscloneable()) {
 						$arg=clone($arg);
-						$cast=method_exists($arg,'cast')?
+						$cast=is_callable($arg,'cast')?
 							$arg->cast():get_object_vars($arg);
 						foreach ($cast as $key=>$val)
 							$arg->$key=$this->recursive(


### PR DESCRIPTION
is_method tripped us up in production, with the error: Fatal error: Call to a member function cast() on array I still don't really understand how but I suspect it maybe because is_callable will check whether the method can be called from this scope, whilst method_exists will only check for the existence of the method 
http://blog.jmfeurprier.com/2010/01/03/method_exists-vs-is_callable/
The downside to this approach is I think is_callable is slower than method_exists but is more reliable I think for this case
