### PR TITLE
Adding support for composer autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,10 @@
 			"type": "vcs",
 			"url": "https://github.com/bcosca/fatfree"
 		}
-	]
+	],
+	"autoload": {
+		"psr-4": {
+			"": "lib/"
+		}
+	}
 }


### PR DESCRIPTION
This adds support for Composer autoloading.

Instead of having to specify the full path to base.php, users can then simply do:

```
Base::instance();
```

This is primarily useful if you are writing your own wrapper class to extend Base.
