### PR TITLE
NEW: custom config section

### DIFF
--- a/app.ini
+++ b/app.ini
@@ -39,3 +39,9 @@ os=PHP_OS
 
 long="12345678901234567890"
 huge=12345678901234567890
+
+[section1]
+myvar=myval1
+
+[section2]
+myvar=myval2

--- a/app/config.php
+++ b/app/config.php
@@ -10,6 +10,9 @@ class Config extends Controller {
 			is_null($f3->get('ERROR')),
 			'No errors expected at this point'
 		);
+		$f3->set('CONFIG',function($sec,$lval,$rval) use($f3){
+			$f3->set($sec.'.'.$lval,strtoupper($rval));
+		});
 		$f3->config('app.ini');
 		$test->expect(
 			$f3->get('test')=='',
@@ -68,6 +71,10 @@ class Config extends Controller {
 		$test->expect(
 			in_array('/map',$routes),
 			'ReST map declared'
+		);
+		$test->expect(
+			$f3->get('section1.myvar')=='MYVAL1' && $f3->get('section2.myvar')=='MYVAL2',
+			'Custom section'
 		);
 		$f3->set('results',$test->results());
 	}

--- a/lib/base.php
+++ b/lib/base.php
@@ -1502,8 +1502,10 @@ class Base extends Prefab implements ArrayAccess {
 						str_getcsv(preg_replace('/(?<!\\\\)(")(.*?)\1/',
 							"\\1\x00\\2\\1",$match['rval']))
 					);
-					call_user_func_array(array($this,'set'),
+					$custom=$this->hive['CONFIG'] && $sec!='globals';//custom section
+					call_user_func_array($custom?$this->hive['CONFIG']:array($this,'set'),
 						array_merge(
+							$custom?array($sec):array(),
 							array($match['lval']),
 							count($args)>1?array($args):$args));
 				}
@@ -1821,6 +1823,7 @@ class Base extends Prefab implements ArrayAccess {
 			'BODY'=>NULL,
 			'CACHE'=>FALSE,
 			'CASELESS'=>TRUE,
+			'CONFIG'=>NULL,
 			'DEBUG'=>0,
 			'DIACRITICS'=>array(),
 			'DNSBL'=>'',


### PR DESCRIPTION
Hi, here is a proposal for adding a `CONFIG` variable, allowing to handle custom sections in configuration files.

At the moment, any section other than `[routes]`, `[maps]` and `[redirects]` is treated as `[globals]`.

This PR offers to handle custom sections with a custom callback:

``` php
$f3->set('CONFIG',function($section,$left,$right){
  //being in $section, do something with the $left/$right config values
});
```

This opens a range of possibilities, for example:

``` ini
;Development environement
[dev]
api_key = foo

;Production environment
[prod]
api_key = bar
```

or

``` ini
;Front
[routes]
GET / = App\Front->home

;Back office
[routes:admin]
GET /admin = App\Backoffice->home
```

or

``` ini
;Every property below will be stored in the $f3->get('BLOG') variable 
[prefix:BLOG]
param1 = val1
param2 = val2

;Every property below will be stored in the $f3->get('CONTACT') variable 
[prefix:CONTACT]
recipients = addr1, addr2
```
