### PR TITLE
Replacing PSR-4 autoloading with a standard file map

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,6 @@
 		}
 	],
 	"autoload": {
-		"psr-4": {
-			"": "lib/"
-		}
+		"files": ["lib/base.php"]
 	}
 }


### PR DESCRIPTION
PSR-4 autoloading will not work because of the case difference (file is base but class is Base). This replaces it with a standard file map to include base.php with the Composer autoload.
