### PR TITLE
language fallback: minor fixes

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -330,7 +330,7 @@ final class Base extends Prefab implements ArrayAccess {
 			$this->fallback=$val;
 			$lang=$this->language($this->hive['LANGUAGE']);
 		case 'LANGUAGE':
-			if (isset($lang) || $lang=$this->language($val))
+			if (!isset($lang))
 				$val=$this->language($val);
 			$lex=$this->lexicon($this->hive['LOCALES']);
 		case 'LOCALES':
@@ -923,7 +923,7 @@ final class Base extends Prefab implements ArrayAccess {
 	**/
 	function lexicon($path) {
 		$lex=array();
-		foreach ($this->languages?:array($this->fallback) as $lang) {
+		foreach ($this->languages?:explode(',',$this->fallback) as $lang) {
 			if ((is_file($file=($base=$path.$lang).'.php') ||
 				is_file($file=$base.'.php')) &&
 				is_array($dict=require($file)))


### PR DESCRIPTION
This PR intends to fix 3 small bugs:
- `lexicon` doesn't handle the case where `FALLBACK` is a csv string
- when setting `FALLBACK` to a language+country code, `FALLBACK` and `$fallback` get out of sync:

``` php
$f3->set('FALLBACK','fr-FR');
//=> FALLBACK is actually set to 'fr-FR,fr'
//=> but internal $fallback is set to 'fr-FR'
```
- when setting `LANGUAGE` prior to `FALLBACK`, `LANGUAGE` is erased:

``` php
$f3->set('LANGUAGE','it');
$f3->set('FALLBACK','fr-FR');
//=> LANGUAGE is set to 'fr-FR,fr'
```
