### PR TITLE
One liner. Add a slash to prevent dir being interpreted as a file.

### DIFF
--- a/lib/db/jig.php
+++ b/lib/db/jig.php
@@ -71,7 +71,7 @@ class Jig {
 				$out=$fw->serialize($data);
 				break;
 		}
-		return $fw->write($this->dir.$file,$out);
+		return $fw->write($this->dir.'/'.$file,$out);
 	}
 
 	/**


### PR DESCRIPTION
Add a slash to prevent dir being interpreted as a file.

I think I read somewhere that F3's policy is that dirs are only dirs when there is a slash on the end. But This does not hold here, because the dir in question is already being interpreted/allowed as a dir without question. 

The consequences of this bug was that 1. \DB\Jig\drop() was broken if the user does not put a slash on the end. 2. files are created instead of dirs.
