### PR TITLE
base::config()

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -1428,7 +1428,7 @@ class Base extends Prefab {
 		preg_match_all(
 			'/(?<=^|\n)(?:'.
 				'\[(?<section>.+?)\]|'.
-				'(?<lval>[^\h\r\n;].+?)\h*=\h*'.
+				'(?<lval>[^\h\r\n;].*?)\h*=\h*'.
 				'(?<rval>(?:\\\\\h*\r?\n|.+?)*)'.
 			')(?=\r?\n|$)/',
 			$this->read($file),$matches,PREG_SET_ORDER);
@@ -1457,9 +1457,10 @@ class Base extends Prefab {
 						str_getcsv(preg_replace('/(?<!\\\\)(")(.*?)\1/',
 							"\\1\x00\\2\\1",$match['rval']))
 					);
+					$lval = $sec == 'globals' ? $match['lval'] : $sec .'.'. $match['lval'];
 					call_user_func_array(array($this,'set'),
 						array_merge(
-							array($match['lval']),
+							array($lval),
 							count($args)>1?array($args):$args));
 				}
 			}


### PR DESCRIPTION
Documentation example for custom configuration sections (http://fatfreeframework.com/framework-variables#Customsections) was not working for me.
- regex for lval wouldn't match variables that are single letter
- variables in custom sections were not being prefixed with the section name - just added directly into globals

This alters the regex to allow single-character variables, and adds the section prefix when the section is not 'globals'.  Now the `[foo]` ... `[foo.hash]` example works.

Question: is this the correct way to add the section prefix?
