### PR TITLE
Fix 'Array to string conversion' error when AUTOLOAD is an array

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -1567,6 +1567,8 @@ class Base extends Prefab {
 	protected function autoload($class) {
 		$class=$this->fixslashes(ltrim($class,'\\'));
 		foreach ($this->split($this->hive['PLUGINS'].';'.
+			is_array($this->hive['AUTOLOAD']) ?
+			join(';', $this->hive['AUTOLOAD']) :
 			$this->hive['AUTOLOAD']) as $auto)
 			if (is_file($file=$auto.$class.'.php') ||
 				is_file($file=$auto.strtolower($class).'.php') ||


### PR DESCRIPTION
There may be a better option performance wise, but this was the simplest version.
