### PR TITLE
Migrate to composer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "lib"]
-	path = lib
-	url = https://github.com/bcosca/fatfree-core.git

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,17 @@
+{
+	"name": "bcosca/fatfree",
+	"description": "A powerful yet easy-to-use PHP micro-framework designed to help you build dynamic and robust Web applications - fast!",
+	"homepage": "http://fatfreeframework.com/",
+	"license": "GPL-3.0",
+	"require": {
+		"php": ">=5.3.6",
+		"bcosca/fatfree-core": "dev-master"
+	},
+	"repositories": [
+		{
+			"type": "vcs",
+			"url": "https://github.com/bcosca/fatfree-core"
+		}
+	]
+}
+

--- a/index.php
+++ b/index.php
@@ -1,6 +1,7 @@
 <?php
 
-$f3=require('lib/base.php');
+require_once 'vendor/autoload.php';
+$f3 = \Base::instance();
 
 $f3->set('DEBUG',2);
 $f3->set('UI','ui/');

--- a/readme.md
+++ b/readme.md
@@ -111,7 +111,8 @@ Upgrade if necessary and come back here if you've made the jump to PHP 5.3 or a 
 Time to start writing our first application:-
 
 ``` php
-$f3 = require('path/to/base.php');
+require('path/to/base.php');
+$f3 = \Base::instance();
 $f3->route('GET /',
     function() {
         echo 'Hello, world!';
@@ -120,7 +121,14 @@ $f3->route('GET /',
 $f3->run();
 ```
 
-Prepend `base.php` on the first line with the appropriate path. Save the above code fragment as `index.php` in your Web root folder. We've written our first Web page.
+Prepend `base.php` on the first line with the appropriate path. Save the above code fragment as `index.php` in your Web root folder. We've just written our first Web page.
+
+If your installing via composer, replace the first two lines with the following two (the examples in the rest of this document assume your not using composer, but the only difference as far as loading F3 is concerned is these two lines):
+
+``` php
+require('vendor/autoload.php');
+$f3 = \Base::instance();
+```
 
 The first command tells the PHP interpreter that you want the framework's functions and features available to your application. The `$f3->route()` method informs Fat-Free that a Web page is available at the relative URL indicated by the slash (`/`). Anyone visiting your site located at `http://www.example.com/` will see the `'Hello, world!'` message because the URL `/` is equivalent to the root page. To create a route that branches out from the root page, like `http://www.example.com/inside/`, you can define another route with a simple `GET /inside` string.
 


### PR DESCRIPTION
Bite the bullet migrate F3 to composer. With this change, F3 now requires fatfree-core via composer. Submodule is gone. Essentially, the bcosca/fatfree repo now serves as a sample application, documentation, and container for tests all in one. Bit weird but works well. Refs #761.

Note, at current there is a bug in the fatfree-core composer.json that stops it autoloading classes. PRd (/bcosca/fatfree-core#31) fix. This works with that.
