### PR TITLE
Updated View tests to use the new default encoding

### DIFF
--- a/app/internals.php
+++ b/app/internals.php
@@ -111,14 +111,7 @@ class Internals extends Controller {
 		);
 		$test->expect(
 			$f3->encode('I\'ll "walk" the <b>dog</b> now™')==
-				($out='I\'ll &quot;walk&quot; the &lt;b&gt;dog&lt;'.
-				'/b&gt; now&trade;'),
-			'Encode HTML entities'
-		);
-		$test->expect(
-			$f3->encode('I\'ll "walk" the <b>dog</b> now™')==
-				($out='I\'ll &quot;walk&quot; the &lt;b&gt;dog&lt;'.
-				'/b&gt; now&trade;'),
+				($out='I\'ll &quot;walk&quot; the &lt;b&gt;dog&lt;/b&gt; now™'),
 			'Encode HTML entities'
 		);
 		$test->expect(

--- a/app/template.php
+++ b/app/template.php
@@ -144,7 +144,7 @@ class Template extends Controller {
 		);
 		$f3->set('foo','barré');
 		$test->expect(
-			$tpl->render('templates/test2b.htm')=='barr&eacute;barr&eacute;',
+			$tpl->render('templates/test2b.htm')=='barrébarré',
 			'double <include> doesn\'t double encode'
 		);
 		$f3->clear('cond');

--- a/app/view.php
+++ b/app/view.php
@@ -12,8 +12,8 @@ class View extends Controller {
 		);
 		$view=\View::instance();
 		$raw='<&>"\'ä';
-		$escaped="&lt;&amp;&gt;&quot;'&auml;";
-		$escapedTwice="&amp;lt;&amp;amp;&amp;gt;&amp;quot;'&amp;auml;";
+		$escaped="&lt;&amp;&gt;&quot;'ä";
+		$escapedTwice="&amp;lt;&amp;amp;&amp;gt;&amp;quot;'ä";
 		$f3->set('test',$raw);
 		$test->expect(
 			$view->esc($raw)==$escaped,


### PR DESCRIPTION
Passing `View` tests for `fatfree-core` [`2134fe1f67ba6fc78ae79b35816050acd0da8a06`](https://github.com/bcosca/fatfree-core/commit/2134fe1f67ba6fc78ae79b35816050acd0da8a06) or newer.