### PR TITLE
Support for arbitrary HTTP server ports

### DIFF
--- a/ui/layout.htm
+++ b/ui/layout.htm
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<base href="{{ @SCHEME.'://'.@HOST.@BASE.'/'.@UI }}" />
+		<base href="{{ @SCHEME.'://'.@HOST.@BASE.(!@PORT||@PORT==80||@PORT==443?'':':'.@PORT).'/'.@UI }}" />
+
 		<meta charset="{{ @ENCODING}}" />
 		<title>{{ @VERSION }}: {{ @active }}</title>
 		<link rel="stylesheet" type="text/css" href="css/theme.css" />

--- a/ui/layout.htm
+++ b/ui/layout.htm
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<base href="{{ @SCHEME.'://'.@HOST.@BASE.(!@PORT||@PORT==80||@PORT==443?'':':'.@PORT).'/'.@UI }}" />
+		<base href="{{ @SCHEME.'://'.@HOST.(!@PORT||@PORT==80||@PORT==443?'':':'.@PORT).@BASE.'/'.@UI }}" />
 
 		<meta charset="{{ @ENCODING}}" />
 		<title>{{ @VERSION }}: {{ @active }}</title>


### PR DESCRIPTION
This pull request fixes the invalid `base` URI when running a HTTP server with a custom port, e.g. `php -S 127.0.0.1:9000`.