### PR TITLE
Update markdown.php

### DIFF
--- a/lib/markdown.php
+++ b/lib/markdown.php
@@ -349,18 +349,9 @@ class Markdown extends Prefab {
 	protected function _img($str) {
 		$self=$this;
 		return preg_replace_callback(
-			'/!(?:\[(.+?)\])?\h*\(<?(.*?)>?(?:\h*"(.*?)"\h*)?\)/',
-			function($expr) use($self) {
-				return '<img src="'.$expr[2].'"'.
-					(empty($expr[1])?
-						'':
-						(' alt="'.$self->esc($expr[1]).'"')).
-					(empty($expr[3])?
-						'':
-						(' title="'.$self->esc($expr[3]).'"')).' />';
-			},
-			$str
-		);
+		'/!(?:\[(.+?)\])?\h*\(<?(.*?)>?(?:\h*"(.*?)"\h*)?\)?(?:\h*"(.*?)"\h*)?\)?(?:\h*"(.*?)"\h*)?\)/', function($expr) use($self){
+			return '<img src="'.$expr[2].'"'.(empty($expr[1])?'':(' alt="'.$self->esc($expr[1]).'"')).(empty($expr[3])?'':(' title="'.$self->esc($expr[3]).'"')).(' style="height:'.(empty($expr[4])?'auto':($self->esc($expr[4]).'px')).';width:'.(empty($expr[5])?'auto':($self->esc($expr[5]).'px')).'"').'>';
+		},$str);
 	}
 
 	/**


### PR DESCRIPTION
Added Image Dimensions to Markdown Code.

It is possible to add ImageDimensions via:
`![(char) IMAGE_NAME]((char) IMAGE_LOCATION "(char) IMAGE_NAME" "(int) HEIGHT" "(int) WIDTH")`

If only the Parameter for HEIGHT ist found - ImageWidth will be "auto".
If only the Parameter for WIDTH ist found - ImageHeight will be "auto".
