### PR TITLE
ignore cache headers on error

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -1158,6 +1158,7 @@ final class Base extends Prefab implements ArrayAccess {
 			'text'=>$text,
 			'trace'=>$trace
 		);
+		$this->expire(-1);
 		$handler=$this->hive['ONERROR'];
 		$this->hive['ONERROR']=NULL;
 		$eol="\n";


### PR DESCRIPTION
Http cache control headers (``Cache-Control:`` and ``Expires:``) configured as 3rd argument of ``$f3->route`` are sent regardless of HTTP Response code. 

Errors cached by browsers may lead to problems, for example if error is caused by temporary back-end problems, client browser will return an error until cache expires, even if its fixed server side. This may not be happening on all browsers and I only seen this on Android browser. But there might be more cases. In any case I think there is no point in caching error responses.

Dummy example:
```php
$f3->route('GET /error', function($f3){

	$f3->error(500, 'oops something happened');	
}, 24*3600);
```

In the above scenario, cache headers are sent as per 3rd argument for 24hrs.
They should **not** be sent, only for successful responses.
