### PR TITLE
Update fatfree app and test to support namespace F3 update made to fatfree-core in #112.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib"]
-	path = lib
+	path = f3
 	url = https://github.com/bcosca/fatfree-core.git

--- a/app/audit.php
+++ b/app/audit.php
@@ -5,12 +5,12 @@ namespace App;
 class Audit extends Controller {
 
 	function get($f3) {
-		$test=new \Test;
+		$test=new \F3\Test;
 		$test->expect(
 			is_null($f3->get('ERROR')),
 			'No errors expected at this point'
 		);
-		$audit=new \Audit;
+		$audit=new \F3\Audit;
 		$test->expect(
 			!$audit->url('http://www.example.com/space here.html') &&
 			$audit->url('http://www.example.com/space%20here.html'),

--- a/app/auth.php
+++ b/app/auth.php
@@ -5,20 +5,20 @@ namespace App;
 class Auth extends Controller {
 
 	function get($f3) {
-		$test=new \Test;
+		$test=new \F3\Test;
 		$test->expect(
 			is_null($f3->get('ERROR')),
 			'No errors expected at this point'
 		);
 		if (!is_dir('tmp/'))
-			mkdir('tmp/',\Base::MODE,TRUE);
-		$db=new \DB\Jig('tmp/');
+			mkdir('tmp/',\F3\Base::MODE,TRUE);
+		$db=new \F3\DB\Jig('tmp/');
 		$db->drop();
-		$user=new \DB\Jig\Mapper($db,'users');
+		$user=new \F3\DB\Jig\Mapper($db,'users');
 		$user->set('user_id','admin');
 		$user->set('password','secret');
 		$user->save();
-		$auth=new \Auth($user,array('id'=>'user_id','pw'=>'password'));
+		$auth=new \F3\Auth($user,array('id'=>'user_id','pw'=>'password'));
 		$test->expect(
 			$auth->basic(),
 			'HTTP basic auth mechanism'
@@ -30,13 +30,13 @@ class Auth extends Controller {
 		$db->drop();
 		if (extension_loaded('mongo')) {
 			try {
-				$db=new \DB\Mongo('mongodb://localhost:27017','test');
+				$db=new \F3\DB\Mongo('mongodb://localhost:27017','test');
 				$db->drop();
-				$user=new \DB\Mongo\Mapper($db,'users');
+				$user=new \F3\DB\Mongo\Mapper($db,'users');
 				$user->set('user_id','admin');
 				$user->set('password','secret');
 				$user->save();
-				$auth=new \Auth($user,
+				$auth=new \F3\Auth($user,
 					array('id'=>'user_id','pw'=>'password'));
 				$test->expect(
 					$auth->login('admin','secret') &&
@@ -48,7 +48,7 @@ class Auth extends Controller {
 			}
 		}
 		if (extension_loaded('pdo_sqlite')) {
-			$db=new \DB\SQL('sqlite::memory:');
+			$db=new \F3\DB\SQL('sqlite::memory:');
 			$db->exec(
 				'CREATE TABLE users ('.
 					'user_id VARCHAR(30),'.
@@ -56,11 +56,11 @@ class Auth extends Controller {
 					'PRIMARY KEY(user_id)'.
 				');'
 			);
-			$user=new \DB\SQL\Mapper($db,'users');
+			$user=new \F3\DB\SQL\Mapper($db,'users');
 			$user->set('user_id','admin');
 			$user->set('password','secret');
 			$user->save();
-			$auth=new \Auth($user,
+			$auth=new \F3\Auth($user,
 				array('id'=>'user_id','pw'=>'password'));
 			$test->expect(
 				$auth->login('admin','secret') &&

--- a/app/autoload.php
+++ b/app/autoload.php
@@ -5,7 +5,7 @@ namespace App;
 class Autoload extends Controller {
 
 	function get($f3) {
-		$test=new \Test;
+		$test=new \F3\Test;
 		$test->expect(
 			is_null($f3->get('ERROR')),
 			'No errors expected at this point'
@@ -43,7 +43,7 @@ class Autoload extends Controller {
 			'NS\NS6\NS7\C: ns/ns6/ns7/c.php'
 		);
 		$test->expect(
-			class_exists('\Cache'),
+			class_exists('\F3\Cache'),
 			'Class in root namespace: lib/base.php'
 		);
 		$f3->set('results',$test->results());

--- a/app/basket.php
+++ b/app/basket.php
@@ -5,12 +5,12 @@ namespace App;
 class Basket extends Controller {
 
 	function get($f3) {
-		$test=new \Test;
+		$test=new \F3\Test;
 		$test->expect(
 			is_null($f3->get('ERROR')),
 			'No errors expected at this point'
 		);
-		$basket=new \Basket;
+		$basket=new \F3\Basket;
 		$test->expect(
 			is_object($basket),
 			'Cursor instantiated'

--- a/app/cache.php
+++ b/app/cache.php
@@ -5,7 +5,7 @@ namespace App;
 class Cache extends Controller {
 
 	function get($f3) {
-		$test=new \Test;
+		$test=new \F3\Test;
 		$test->expect(
 			is_null($f3->get('ERROR')),
 			'No errors expected at this point'
@@ -26,9 +26,9 @@ class Cache extends Controller {
 		);
 		$repeat=TRUE;
 		while ($repeat) {
-			$cache=\Cache::instance();
+			$cache=\F3\Cache::instance();
 			$test->expect(
-				$cache===\Cache::instance(),
+				$cache===\F3\Cache::instance(),
 				'Same cache engine instance returned'
 			);
 			$cache->set($f3->hash('foo').'.var','bar',0.05);
@@ -154,7 +154,7 @@ class Cache extends Controller {
 					sprintf('%.1f',(microtime(TRUE)-$mark)*1e3).'ms'
 			);
 			$cache->clear($hash);
-			$session=new \Session;
+			$session=new \F3\Session;
 			$test->expect(
 				$session->sid()===NULL,
 				'Cache-based session instantiated but not started'

--- a/app/config.php
+++ b/app/config.php
@@ -5,7 +5,7 @@ namespace App;
 class Config extends Controller {
 
 	function get($f3) {
-		$test=new \Test;
+		$test=new \F3\Test;
 		$test->expect(
 			is_null($f3->get('ERROR')),
 			'No errors expected at this point'

--- a/app/controller.php
+++ b/app/controller.php
@@ -15,7 +15,7 @@ class Controller {
 	}
 
 	function afterroute() {
-		echo \Preview::instance()->render('layout.htm');
+		echo \F3\Preview::instance()->render('layout.htm');
 	}
 
 }

--- a/app/geo.php
+++ b/app/geo.php
@@ -5,12 +5,12 @@ namespace App;
 class Geo extends Controller {
 
 	function get($f3) {
-		$test=new \Test;
+		$test=new \F3\Test;
 		$test->expect(
 			is_null($f3->get('ERROR')),
 			'No errors expected at this point'
 		);
-		$geo=new \Web\Geo;
+		$geo=new \F3\Web\Geo;
 		$test->expect(
 			($info=$geo->tzinfo($tz=$f3->get('TZ'))) &&
 				isset($info['offset']) && isset($info['country']) &&

--- a/app/globals.php
+++ b/app/globals.php
@@ -5,7 +5,7 @@ namespace App;
 class Globals extends Controller {
 
 	function get($f3) {
-		$test=new \Test;
+		$test=new \F3\Test;
 		$test->expect(
 			is_null($f3->get('ERROR')),
 			'No errors expected at this point'

--- a/app/google.php
+++ b/app/google.php
@@ -5,13 +5,13 @@ namespace App;
 class Google extends Controller {
 
 	function get($f3) {
-		$test=new \Test;
+		$test=new \F3\Test;
 		$test->expect(
 			is_null($f3->get('ERROR')),
 			'No errors expected at this point'
 		);
-		$f3=\Base::instance();
-		$map=new \Web\Google\StaticMap;
+		$f3=\F3\Base::instance();
+		$map=new \F3\Web\Google\StaticMap;
 		$test->expect(
 			$img=$f3->base64(
 				$map->center('Brooklyn Bridge, New York, NY')->zoom(13)->

--- a/app/helper.php
+++ b/app/helper.php
@@ -2,7 +2,7 @@
 
 namespace App;
 
-class Helper extends \Prefab {
+class Helper extends \F3\Prefab {
 
 	function pick($val,$match) {
 		return preg_grep('/'.$match.'/',$val);

--- a/app/hive.php
+++ b/app/hive.php
@@ -5,7 +5,7 @@ namespace App;
 class Hive extends Controller {
 
 	function get($f3) {
-		$test=new \Test;
+		$test=new \F3\Test;
 		$test->expect(
 			is_null($f3->get('ERROR')),
 			'No errors expected at this point'

--- a/app/image.php
+++ b/app/image.php
@@ -5,7 +5,7 @@ namespace App;
 class Image extends Controller {
 
 	function get($f3) {
-		$test=new \Test;
+		$test=new \F3\Test;
 		$test->expect(
 			is_null($f3->get('ERROR')),
 			'No errors expected at this point'
@@ -15,7 +15,7 @@ class Image extends Controller {
 			'GD2 extension loaded'
 		);
 		if ($loaded) {
-			$img=new \Image;
+			$img=new \F3\Image;
 			$test->expect(
 				$src=$f3->base64(
 					$img->captcha('fonts/thunder.ttf')->
@@ -44,9 +44,9 @@ class Image extends Controller {
 				'<img src="'.$src.'" title="Identicon" />'
 			);
 			$f3->set('file','images/south-park.jpg');
-			$img=new \Image($f3->get('file'),TRUE);
+			$img=new \F3\Image($f3->get('file'),TRUE);
 			$test->expect(
-				$orig=\View::instance()->render('image.htm'),
+				$orig=\F3\View::instance()->render('image.htm'),
 				'Original image rendered from template<br />'.$orig
 			);
 			$test->expect(
@@ -166,17 +166,17 @@ class Image extends Controller {
 				'<img src="'.$src.'" '.
 					'title="'.$img->width().'x'.$img->height().'" />'
 			);
-			$ovr=new \Image('images/watermark.png');
+			$ovr=new \F3\Image('images/watermark.png');
 			$ovr->resize(100,38)->rotate(90);
 			$test->expect(
 				$src=$f3->base64($img->restore()->
-					overlay($ovr,\Image::POS_Right|\Image::POS_Middle)->
+					overlay($ovr,\F3\Image::POS_Right|\F3\Image::POS_Middle)->
 					dump(),'image/png'),
 				'Overlay<br />'.
 				'<img src="'.$src.'" '.
 					'title="'.$img->width().'x'.$img->height().'" />'
 			);
-			$ovr=new \Image('images/watermark.png');
+			$ovr=new \F3\Image('images/watermark.png');
 			$ovr->resize(100,38)->rotate(45);
 			$test->expect(
 				$src=$f3->base64($img->restore()->

--- a/app/internals.php
+++ b/app/internals.php
@@ -5,7 +5,7 @@ namespace App;
 class Internals extends Controller {
 
 	function get($f3) {
-		$test=new \Test;
+		$test=new \F3\Test;
 		$test->expect(
 			is_null($f3->get('ERROR')),
 			'No errors expected at this point'
@@ -24,7 +24,7 @@ class Internals extends Controller {
 		);
 		$f3->foo='bar';
 		$test->expect(
-			$f3===\Base::instance() && @\Base::instance()->foo=='bar',
+			$f3===\F3\Base::instance() && @\F3\Base::instance()->foo=='bar',
 			'Same framework instance returned'
 		);
 		$test->expect(
@@ -125,17 +125,17 @@ class Internals extends Controller {
 			$f3->decode($out)=='I\'ll "walk" the <b>dog</b> now™',
 			'Decode HTML entities'
 		);
-		$obj=\Matrix::instance();
+		$obj=\F3\Matrix::instance();
 		$test->expect(
-			\Registry::exists($class=get_class($obj)),
+			\F3\Registry::exists($class=get_class($obj)),
 			'instance() saves object to framework registry'
 		);
 		$test->expect(
-			$f3->constants($f3,'REQ_')==array('SYNC'=>\Base::REQ_SYNC,'AJAX'=>\Base::REQ_AJAX),
+			$f3->constants($f3,'REQ_')==array('SYNC'=>\F3\Base::REQ_SYNC,'AJAX'=>\F3\Base::REQ_AJAX),
 			'Fetch constants from a class (object)'
 		);
 		$test->expect(
-			$f3->constants('ISO','CC_')==\ISO::instance()->countries(),
+			$f3->constants('\F3\ISO','CC_')==\F3\ISO::instance()->countries(),
 			'Fetch constants from a class (string)'
 		);
 		$f3->set('results',$test->results());

--- a/app/jig.php
+++ b/app/jig.php
@@ -5,12 +5,12 @@ namespace App;
 class Jig extends Controller {
 
 	function get($f3) {
-		$test=new \Test;
+		$test=new \F3\Test;
 		$test->expect(
 			is_null($f3->get('ERROR')),
 			'No errors expected at this point'
 		);
-		$db=new \DB\Jig;
+		$db=new \F3\DB\Jig;
 		$db->drop();
 		$test->expect(
 			is_object($db),
@@ -20,7 +20,7 @@ class Jig extends Controller {
 			$uuid=$db->uuid(),
 			'UUID: '.$uuid
 		);
-		$movie=new \DB\Jig\Mapper($db,'movies');
+		$movie=new \F3\DB\Jig\Mapper($db,'movies');
 		$test->expect(
 			$type=$movie->dbtype(),
 			'DB type: '.$type
@@ -221,7 +221,7 @@ class Jig extends Controller {
 		$obj=$movie->findone(array('@title=?','Zodiac'));
 		$class=get_class($obj);
 		$test->expect(
-			$class=='DB\Jig\Mapper' &&
+			$class=='F3\DB\Jig\Mapper' &&
 			$obj->get('title')=='Zodiac' &&
 			$obj->get('director')=='David Fincher' &&
 			$obj->get('year')==2007,
@@ -233,7 +233,7 @@ class Jig extends Controller {
 			$obj['year']==2007,
 			'Associative array access'
 		);
-		$session=new \DB\Jig\Session($db);
+		$session=new \F3\DB\Jig\Session($db);
 		$test->expect(
 			$session->sid()===NULL,
 			'Database-managed session instantiated but not started'

--- a/app/lexicon.php
+++ b/app/lexicon.php
@@ -5,7 +5,7 @@ namespace App;
 class Lexicon extends Controller {
 
 	function get($f3) {
-		$test=new \Test;
+		$test=new \F3\Test;
 		$test->expect(
 			is_null($f3->get('ERROR')),
 			'No errors expected at this point'
@@ -19,7 +19,7 @@ class Lexicon extends Controller {
 			$language=$f3->get('LANGUAGE'),
 			'LANGUAGE: '.$language.' auto-detected'
 		);
-		$template=\Template::instance();
+		$template=\F3\Template::instance();
 		$f3->set('LANGUAGE','fr-FR');
 		$test->expect(
 			substr_count($f3->decode($template->render('templates/lexicon.htm')),

--- a/app/log.php
+++ b/app/log.php
@@ -5,13 +5,13 @@ namespace App;
 class Log extends Controller {
 
 	function get($f3) {
-		$test=new \Test;
+		$test=new \F3\Test;
 		$test->expect(
 			is_null($f3->get('ERROR')),
 			'No errors expected at this point'
 		);
 		$f3->set('LOGS',$tmp=$f3->get('TEMP'));
-		$log=new \Log($name='test.log');
+		$log=new \F3\Log($name='test.log');
 		if (is_file($file=$tmp.$name))
 			$log->erase();
 		$log->write('foo');

--- a/app/markdown.php
+++ b/app/markdown.php
@@ -5,12 +5,12 @@ namespace App;
 class Markdown extends Controller {
 
 	function get($f3) {
-		$test=new \Test;
+		$test=new \F3\Test;
 		$test->expect(
 			is_null($f3->get('ERROR')),
 			'No errors expected at this point'
 		);
-		$md=\Markdown::instance();
+		$md=\F3\Markdown::instance();
 		$cases=array(
 			'Code Blocks',
 			'Blockquotes with code blocks',

--- a/app/matrix.php
+++ b/app/matrix.php
@@ -5,7 +5,7 @@ namespace App;
 class Matrix extends Controller {
 
 	function get($f3) {
-		$test=new \Test;
+		$test=new \F3\Test;
 		$test->expect(
 			is_null($f3->get('ERROR')),
 			'No errors expected at this point'
@@ -16,7 +16,7 @@ class Matrix extends Controller {
 			array('id'=>345,'name'=>'george','sales'=>0.57),
 			array('id'=>234,'name'=>'john','sales'=>0.79)
 		);
-		$matrix=\Matrix::instance();
+		$matrix=\F3\Matrix::instance();
 		$matrix->sort($array,'name');
 		$test->expect(
 			$array==array(

--- a/app/mongo.php
+++ b/app/mongo.php
@@ -5,7 +5,7 @@ namespace App;
 class Mongo extends Controller {
 
 	function get($f3) {
-		$test=new \Test;
+		$test=new \F3\Test;
 		$test->expect(
 			is_null($f3->get('ERROR')),
 			'No errors expected at this point'
@@ -16,7 +16,7 @@ class Mongo extends Controller {
 		);
 		if ($loaded) {
 			try {
-				$db=new \DB\Mongo('mongodb://localhost:27017','test');
+				$db=new \F3\DB\Mongo('mongodb://localhost:27017','test');
 			}
 			catch (\Exception $x) {
 				$db=NULL;
@@ -30,7 +30,7 @@ class Mongo extends Controller {
 					$uuid=$db->uuid(),
 					'UUID: '.$uuid
 				);
-				$movie=new \DB\Mongo\Mapper($db,'movies');
+				$movie=new \F3\DB\Mongo\Mapper($db,'movies');
 				$test->expect(
 					$type=$movie->dbtype(),
 					'DB type: '.$type
@@ -176,7 +176,7 @@ class Mongo extends Controller {
 				$obj=$movie->findone(array('title'=>'Zodiac'));
 				$class=get_class($obj);
 				$test->expect(
-					$class=='DB\Mongo\Mapper' &&
+					$class=='F3\DB\Mongo\Mapper' &&
 					$obj->get('title')=='Zodiac' &&
 					$obj->get('director')=='David Fincher' &&
 					$obj->get('year')==2007,
@@ -188,7 +188,7 @@ class Mongo extends Controller {
 					$obj['year']==2007,
 					'Associative array access'
 				);
-				$session=new \DB\Mongo\Session($db);
+				$session=new \F3\DB\Mongo\Session($db);
 				$test->expect(
 					$session->sid()===NULL,
 					'Database-managed session instantiated but not started'

--- a/app/openid.php
+++ b/app/openid.php
@@ -5,12 +5,12 @@ namespace App;
 class OpenID extends Controller {
 
 	function get($f3) {
-		$test=new \Test;
+		$test=new \F3\Test;
 		$test->expect(
 			is_null($f3->get('ERROR')),
 			'No errors expected at this point'
 		);
-		$openid=new \Web\OpenID;
+		$openid=new \F3\Web\OpenID;
 		$openid->set('identity','https://www.google.com/accounts/o8/id');
 		$openid->set('return_to',
 			$f3->get('SCHEME').'://'.$f3->get('HOST').

--- a/app/openid2.php
+++ b/app/openid2.php
@@ -5,13 +5,13 @@ namespace App;
 class OpenID2 extends Controller {
 
 	function get($f3) {
-		$test=new \Test;
+		$test=new \F3\Test;
 		$f3->set('results',$test->results());
 		$test->expect(
 			is_null($f3->get('ERROR')),
 			'No errors expected at this point'
 		);
-		$openid=new \Web\OpenID;
+		$openid=new \F3\Web\OpenID;
 		$test->expect(
 			$openid->verified(),
 			'OpenID '.$openid->get('identity').' verified'

--- a/app/pingback.php
+++ b/app/pingback.php
@@ -6,7 +6,7 @@ class Pingback extends Controller {
 
 	function get($f3) {
 		// Client
-		$test=new \Test;
+		$test=new \F3\Test;
 		$test->expect(
 			is_null($f3->get('ERROR')),
 			'No errors expected at this point'
@@ -16,7 +16,7 @@ class Pingback extends Controller {
 			'XML-RPC extension loaded'
 		);
 		if ($loaded) {
-			$pingback=new \Web\Pingback;
+			$pingback=new \F3\Web\Pingback;
 			$source=$f3->get('BASE').'/pingback2?page=pingback/client';
 			$test->expect(
 				$f3->read($f3->get('UI').'pingback/server.htm'),
@@ -33,7 +33,7 @@ class Pingback extends Controller {
 			);
 			$test->expect(
 				@file_get_contents($file)==
-					\View::instance()->render('pingback/client.htm'),
+					\F3\View::instance()->render('pingback/client.htm'),
 				'Read source contents'
 			);
 			@unlink($file);
@@ -53,7 +53,7 @@ class Pingback extends Controller {
 	}
 
 	function post($f3) {
-		\Web\Pingback::instance()->listen(
+		\F3\Web\Pingback::instance()->listen(
 			function($source,$text) use($f3) {
 				$f3->write($f3->get('TEMP').$f3->hash($source).'.htm',$text);
 			}

--- a/app/pingback2.php
+++ b/app/pingback2.php
@@ -5,7 +5,7 @@ namespace App;
 class Pingback2 {
 
 	function get($f3) {
-		die(\View::instance()->render($f3->get('GET.page').'.htm'));
+		die(\F3\View::instance()->render($f3->get('GET.page').'.htm'));
 	}
 
 }

--- a/app/router.php
+++ b/app/router.php
@@ -5,11 +5,11 @@ namespace App;
 class Router extends Controller {
 
 	function callee() {
-		\Base::instance()->set('called',TRUE);
+		\F3\Base::instance()->set('called',TRUE);
 	}
 
 	function get($f3) {
-		$test=new \Test;
+		$test=new \F3\Test;
 		$test->expect(
 			is_null($f3->get('ERROR')),
 			'No errors expected at this point'
@@ -23,7 +23,7 @@ class Router extends Controller {
 		if (is_file($file))
 			@unlink($file);
 		$f3->set('ONREROUTE',function($url,$permanent){
-			$f3=\Base::instance();
+			$f3=\F3\Base::instance();
 			$f3->set('reroute',$url);
 		});
 		$f3->reroute('/foo?bar=baz');
@@ -109,7 +109,7 @@ class Router extends Controller {
 		$f3->map('/dummy','NS\C');
 		$ok=TRUE;
 		$list='';
-		foreach (explode('|',\Base::VERBS) as $verb) {
+		foreach (explode('|',\F3\Base::VERBS) as $verb) {
 			$f3->mock($verb.' /dummy',array('a'=>'hello'));
 			if ($f3->get('route')!=$verb ||
 				preg_match('/GET|HEAD/',strtoupper($verb)) &&
@@ -131,7 +131,7 @@ class Router extends Controller {
 		$f3->mock('OPTIONS /dummy');
 		$test->expect(
 			preg_grep('/Allow: '.
-				str_replace('|',',',\Base::VERBS.'/'),headers_list()),
+				str_replace('|',',',\F3\Base::VERBS.'/'),headers_list()),
 			'HTTP OPTIONS request returns allowed methods'
 		);
 		$f3->clear('ERROR');
@@ -293,7 +293,7 @@ class Router extends Controller {
 		);
 		$f3->clear('called');
 		$f3->call(function() {
-			\Base::instance()->set('called',TRUE);
+			\F3\Base::instance()->set('called',TRUE);
 		});
 		$test->expect(
 			$f3->get('called'),
@@ -313,7 +313,7 @@ class Router extends Controller {
 }
 
 function callee() {
-	\Base::instance()->set('called',TRUE);
+	\F3\Base::instance()->set('called',TRUE);
 }
 
 function a($x) {

--- a/app/sql.php
+++ b/app/sql.php
@@ -5,7 +5,7 @@ namespace App;
 class SQL extends Controller {
 
 	function get($f3) {
-		$test=new \Test;
+		$test=new \F3\Test;
 		$test->expect(
 			is_null($f3->get('ERROR')),
 			'No errors expected at this point'
@@ -16,8 +16,8 @@ class SQL extends Controller {
 		);
 		if ($loaded) {
 			if (!is_dir('tmp/'))
-				mkdir('tmp/',\Base::MODE,TRUE);
-			$db=new \DB\SQL('sqlite:tmp/sqlite.db');
+				mkdir('tmp/',\F3\Base::MODE,TRUE);
+			$db=new \F3\DB\SQL('sqlite:tmp/sqlite.db');
 			$db->exec(
 				array(
 					'PRAGMA temp_store=MEMORY;',
@@ -25,7 +25,7 @@ class SQL extends Controller {
 					'PRAGMA foreign_keys=ON;'
 				)
 			);
-			//$db=new \DB\SQL('mysql:host=localhost');
+			//$db=new \F3\DB\SQL('mysql:host=localhost');
 			$engine=$db->driver();
 			$test->expect(
 				is_object($db),
@@ -44,7 +44,7 @@ class SQL extends Controller {
 					)
 				);
 				unset($db);
-				$db=new \DB\SQL(
+				$db=new \F3\DB\SQL(
 					'mysql:host=localhost;dbname=test');
 			}
 			$db->exec(
@@ -193,7 +193,7 @@ class SQL extends Controller {
 				($schema=$db->schema('movies',NULL,60)) && count($schema)==3,
 				'Schema retrieved'
 			);
-			$movie=new \DB\SQL\Mapper($db,'movies');
+			$movie=new \F3\DB\SQL\Mapper($db,'movies');
 			$test->expect(
 				$type=$movie->dbtype(),
 				'DB type: '.$type
@@ -394,7 +394,7 @@ class SQL extends Controller {
 			$obj=$movie->findone(array($db->quotekey('title').'=?','Zodiac'));
 			$class=get_class($obj);
 			$test->expect(
-				$class=='DB\SQL\Mapper' &&
+				$class=='F3\DB\SQL\Mapper' &&
 				$obj->get('title')=='Zodiac' &&
 				$obj->get('director')=='David Fincher' &&
 				$obj->get('year')==2007,
@@ -433,7 +433,7 @@ class SQL extends Controller {
 					');'
 				)
 			);
-			$ticket=new \DB\SQL\Mapper($db,'tickets');
+			$ticket=new \F3\DB\SQL\Mapper($db,'tickets');
 			$ticket->set('title','The River Murders');
 			$ticket->save();
 			$ticket->save(); // intentional
@@ -504,7 +504,7 @@ class SQL extends Controller {
 				$db->exec(
 					'DROP TABLE IF EXISTS '.$db->quotekey('sessions').';'
 				);
-				$session=new \DB\SQL\Session($db);
+				$session=new \F3\DB\SQL\Session($db);
 				$test->expect(
 					$session->sid()===NULL,
 					'Database-managed session instantiated but not started'

--- a/app/template.php
+++ b/app/template.php
@@ -5,12 +5,12 @@ namespace App;
 class Template extends Controller {
 
 	function get($f3) {
-		$test=new \Test;
+		$test=new \F3\Test;
 		$test->expect(
 			is_null($f3->get('ERROR')),
 			'No errors expected at this point'
 		);
-		$tpl=\Preview::instance();
+		$tpl=\F3\Preview::instance();
 		$f3->set('foo','bar->baz');
 		$test->expect(
 			$tpl->render('templates/test1.htm')=='bar-&gt;baz',
@@ -139,7 +139,7 @@ class Template extends Controller {
 				($eval='$this->esc($foo)'),
 			$expr.': '.$eval
 		);
-		$tpl=\Template::instance();
+		$tpl=\F3\Template::instance();
 		$f3->set('foo','bar');
 		$f3->set('cond',TRUE);
 		$f3->set('file','templates/test1.htm');
@@ -440,13 +440,13 @@ class Template extends Controller {
 			array_fill(0,1000,array_combine(range('a','j'),range(0,9))));
 		$now=microtime(TRUE);
 		$test->expect(
-			\View::instance()->render('benchmark.htm'),
+			\F3\View::instance()->render('benchmark.htm'),
 			'Raw PHP template: '.
 				round(1e3*(microtime(TRUE)-$now),2).' msecs'
 		);
 		$now=microtime(TRUE);
 		$test->expect(
-			\Template::instance()->render('templates/benchmark.htm'),
+			\F3\Template::instance()->render('templates/benchmark.htm'),
 			'Use template engine: '.
 				round(1e3*(microtime(TRUE)-$now),2).' msecs'
 		);

--- a/app/unicode.php
+++ b/app/unicode.php
@@ -5,12 +5,12 @@ namespace App;
 class Unicode extends Controller {
 
 	function get($f3) {
-		$test=new \Test;
+		$test=new \F3\Test;
 		$test->expect(
 			is_null($f3->get('ERROR')),
 			'No errors expected at this point'
 		);
-		$utf=new \UTF;
+		$utf=new \F3\UTF;
 		$test->expect(
 			$len=$utf->strlen('⠊⠀⠉⠁⠝⠀⠑⠁⠞⠀⠛⠇⠁⠎⠎⠀⠁⠝⠙⠀⠊⠞')==22,
 			'strlen'

--- a/app/view.php
+++ b/app/view.php
@@ -5,12 +5,12 @@ namespace App;
 class View extends Controller {
 
 	function get($f3) {
-		$test=new \Test;
+		$test=new \F3\Test;
 		$test->expect(
 			is_null($f3->get('ERROR')),
 			'No errors expected at this point'
 		);
-		$view=\View::instance();
+		$view=\F3\View::instance();
 		$raw='<&>"\'ä';
 		$escaped="&lt;&amp;&gt;&quot;'ä";
 		$escapedTwice="&amp;lt;&amp;amp;&amp;gt;&amp;quot;'ä";

--- a/app/web.php
+++ b/app/web.php
@@ -5,12 +5,12 @@ namespace App;
 class Web extends Controller {
 
 	function get($f3) {
-		$test=new \Test;
+		$test=new \F3\Test;
 		$test->expect(
 			is_null($f3->get('ERROR')),
 			'No errors expected at this point'
 		);
-		$web=\Web::instance();
+		$web=\F3\Web::instance();
 		$test->expect(
 			$web->slug($text='Ñõw is the tîme~for all good mên. to cóme! to the aid 0f-thëir_côuntry')==
 				'now-is-the-time-for-all-good-men-to-come-to-the-aid-0f-their-country',
@@ -74,7 +74,7 @@ class Web extends Controller {
 		$now=microtime(TRUE);
 		$test->expect(
 			$web->minify('js/underscore.js')==
-				\View::instance()->render('js/underscore.min.js'),
+				\F3\View::instance()->render('js/underscore.min.js'),
 			'Minify Javascript ('.round(1e3*(microtime(TRUE)-$now),1).' msecs)'
 		);
 		$now=microtime(TRUE);

--- a/index.php
+++ b/index.php
@@ -1,6 +1,6 @@
 <?php
 
-$f3=require('lib/base.php');
+$f3=require('f3/base.php');
 
 $f3->set('DEBUG',2);
 $f3->set('UI','ui/');

--- a/ns/c.php
+++ b/ns/c.php
@@ -2,7 +2,7 @@
 
 namespace NS;
 
-class C extends \Prefab {
+class C extends \F3\Prefab {
 
 	// Emulate HTTP method so we can test map()
 	function __call($name,$args) {


### PR DESCRIPTION
All references to fatfree-core now prefixed with vendor namespace "F3". Please refer to bcosca/fatfree-core#110.

Note fatfree-core directory has moved from `lib` to `f3`, just because it just worked with the existing f3 autoloader. Submodule references also needs to be updated, but need a commit to reference before that can be done.
