### PR TITLE
Web->request() redirections not working properly for domainless location

### DIFF
--- a/lib/web.php
+++ b/lib/web.php
@@ -292,9 +292,13 @@ class Web extends Prefab {
 		curl_close($curl);
 		$body=ob_get_clean();
 		if ($options['follow_location'] &&
-			preg_match('/^Location: (.+)$/m',implode(PHP_EOL,$headers),$loc)) {
-			$options['max_redirects']--;
-			return $this->request($loc[1],$options);
+		    preg_match('/^Location: (.+)$/m',implode(PHP_EOL,$headers),$loc)) {
+		    $options['max_redirects']--;
+		    if(stripos($loc[1], '/') === 0){
+		        $parsed_url = parse_url($url);
+		        $loc[1] = $parsed_url['scheme'] . '://' . $parsed_url['host'] . $loc[1];
+		    }
+		    return $this->request($loc[1],$options);
 		}
 		return array(
 			'body'=>$body,


### PR DESCRIPTION
Hi, 
I have noticed when you use Web->request() with option "follow_location" and the request response containing "Location: /some-path" header instead of "Location: http://some-domain/some-path", the function requesting wrong address when following the location. It adds domain of the server it is on, not the original domain.

The fix for that would be to add checking if location header is URI without domain, so in web.php around 294 line instead of:

if ($options['follow_location'] &&
    preg_match('/^Location: (.+)$/m',implode(PHP_EOL,$headers),$loc)) {
    $options['max_redirects']--;
    return $this->request($loc[1],$options);
}
make something like:

if ($options['follow_location'] &&
    preg_match('/^Location: (.+)$/m',implode(PHP_EOL,$headers),$loc)) {
    $options['max_redirects']--;
    if(stripos($loc[1], '/') === 0){
        $parsed_url = parse_url($url);
        $loc[1] = $parsed_url['scheme'] . '://' . $parsed_url['host'] . $loc[1];
    }
    return $this->request($loc[1],$options);
}