### PR TITLE
patch the Preview->render() method

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -2810,7 +2810,7 @@ class Preview extends View {
 			$this->mime='text/html';
 		if (!is_dir($tmp=$fw->get('TEMP')))
 			mkdir($tmp,Base::MODE,TRUE);
-		foreach ($fw->split($fw->get('UI')) as $dir) {
+		foreach ($fw->split($fw->get('UI').';./') as $dir) {
 			if ($cache->exists($hash=$fw->hash($dir.$file),$data))
 				return $data;
 			if (is_file($view=$fw->fixslashes($dir.$file))) {


### PR DESCRIPTION
Ran into a 'Unable to open ...' error using the Template render method that was not generated using the View render method. There appeared to be a small inconsistency in parsing the UI global. So i added the small addition .';./' that was present on the View method, now they're both working fine.