### PR TITLE
Added missing bug fix

### DIFF
--- a/lib/CHANGELOG
+++ b/lib/CHANGELOG
@@ -146,6 +146,7 @@ CHANGELOG
 *	Bug fix: encode CLI parameters
 *	Bug fix: Close connection on abort explicitly (#162)
 *	Bug fix: Image->identicon, Avoid double-size sprite rotation (and possible segfault)
+*	Bug fix: Image->render and Image->dump, User had to give NULL as 2nd argument while using jpeg and wbmp
 *	Bug fix: Magic->offsetset, access property as array element (#147)
 *	Bug fix: multi-line custom template tag parsing (bcosca/fatfree#935)
 *	Bug fix: cache headers on errors (bcosca/fatfree#885)


### PR DESCRIPTION
Added missing bugfix for Image->dump() and Image->render() in version 3.6
Like pointed out in #1043 and [Documentation of f3](https://github.com/F3Community/F3com-data/issues/90)