### PR TITLE
added apcu module dependency box for the \"getting started\" splashpage

### DIFF
--- a/index.php
+++ b/index.php
@@ -23,6 +23,7 @@ $f3->route('GET /',
 			'Cache'=>
 				array(
 					'apc',
+					'apcu',
 					'memcache',
 					'memcached',
 					'redis',


### PR DESCRIPTION
Just started the f3 "getting started" guide and was puzzled why my apc(u) setup wasn't being displayed on the default index.php page.