### PR TITLE
Replace index.php rewrite rule with mod_dir FallbackResource setting

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -8,9 +8,5 @@ RewriteEngine On
 # RewriteBase /
 
 RewriteRule ^(tmp)\/|\.ini$ - [R=404]
-
-RewriteCond %{REQUEST_FILENAME} !-l
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteRule .* index.php [L,QSA]
+FallbackResource index.php
 RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization},L]


### PR DESCRIPTION
My first PR to this project! Thank you very much for the awesome work an your effort in bringing a truly fat free framework to PHP!

---
The default `.htaccess` file we ship with F3 uses a rewrite to map all requests to the base `index.php` file. While it is still working, the[ `FallbackResource`](https://httpd.apache.org/docs/2.4/mod/mod_dir.html#fallbackresource) setting can be used to offer the same feature, without additional overhead caused by a rewrite rule. 

Quoting from the documentation linked above:

> In earlier versions of httpd, this effect typically required mod_rewrite, and the use of the -f and -d tests for file and directory existence. This now requires only one line of configuration.

This PR replaces that rewrite with the new setting. We still have to keep the other 2 rewrite rules, but we at least remove one rewrite rule this time. `dir` module is enabled by default.

Thank you!
