### PR TITLE
Allow mock() to set the _POST arguments for PUT and PATCH mehtods

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -1427,7 +1427,7 @@ final class Base extends Prefab implements ArrayAccess {
 		parse_str(@$url['query'],$GLOBALS['_GET']);
 		if (preg_match('/GET|HEAD/',$verb))
 			$GLOBALS['_GET']=array_merge($GLOBALS['_GET'],$args);
-		$GLOBALS['_POST']=$verb=='POST'?$args:[];
+		$GLOBALS['_POST']=($verb=='POST'||$verb=='PUT'||$verb=='PATCH')?$args:[];
 		$GLOBALS['_REQUEST']=array_merge($GLOBALS['_GET'],$GLOBALS['_POST']);
 		foreach ($headers?:[] as $key=>$val)
 			$_SERVER['HTTP_'.strtr(strtoupper($key),'-','_')]=$val;


### PR DESCRIPTION
I had a problem in my tests, that PUT and PATCH ignored the arguments that i passed.

With this pull request I fix this, that also on a PUT or PATCH request will pass the arguments in the _POST.